### PR TITLE
docs: replace gh CLI guidance with curl-based GitHub API instructions

### DIFF
--- a/.github/AGENT_PR_GUIDE.md
+++ b/.github/AGENT_PR_GUIDE.md
@@ -140,6 +140,76 @@ Every PR must verify:
 
 ---
 
+## GitHub Operations — `curl` Only (No `gh` CLI)
+
+> **The `gh` CLI is NOT available in this project's development environment.** This project is developed using Claude Code on the web, which does not have `gh` installed. **Do not attempt to use `gh` commands.** All GitHub API interactions must use `curl` against the [GitHub REST API](https://docs.github.com/en/rest).
+
+Authenticate with the `GITHUB_TOKEN` environment variable, which is automatically available in Claude Code web sessions and CI.
+
+### Creating a Pull Request via `curl`
+
+After pushing your branch, create the PR using the GitHub REST API:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls \
+  -d "$(cat <<'EOF'
+{
+  "title": "feat: your PR title here",
+  "body": "## Tags\n\n- type:feat\n- scope:frontend\n- risk:low\n\n## Summary\n\nDescription of changes.\n\n## Changes\n\n- `path/to/file.ts` — Description\n",
+  "head": "your-branch-name",
+  "base": "main"
+}
+EOF
+)"
+```
+
+**Important notes:**
+- Replace `OWNER/REPO` with the actual repository path (e.g., `Admiralhunter/PortfolioOS`)
+- The PR body should follow the [PR template](pull_request_template.md) format
+- Use `$GITHUB_TOKEN` for authentication — never hardcode tokens
+- Use a heredoc for the JSON body to handle multi-line content and special characters
+
+### Other Common GitHub API Operations
+
+```bash
+# Get PR details
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls/PR_NUMBER
+
+# Add a comment to a PR or issue
+curl -s -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/issues/PR_NUMBER/comments \
+  -d '{"body": "Comment text here"}'
+
+# List PR review comments
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls/PR_NUMBER/comments
+
+# Check CI status for a commit
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/commits/COMMIT_SHA/check-runs
+
+# Merge a pull request
+curl -s -X PUT \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls/PR_NUMBER/merge \
+  -d '{"merge_method": "squash"}'
+```
+
+---
+
 ## Agent Workflow
 
 When an AI agent opens a PR on PortfolioOS, it must follow this process:
@@ -215,6 +285,32 @@ unnecessary trading.
 
 Closes #42
 ```
+
+### Step 8: Open the PR via `curl`
+
+**Do NOT use `gh` CLI** — it is not available. Use `curl` with the GitHub REST API:
+
+```bash
+# Push your branch first
+git push -u origin your-branch-name
+
+# Create the PR
+curl -s -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls \
+  -d "$(cat <<'EOF'
+{
+  "title": "feat: your PR title",
+  "body": "Paste your filled-out PR template here",
+  "head": "your-branch-name",
+  "base": "main"
+}
+EOF
+)"
+```
+
+See the [GitHub Operations](#github-operations--curl-only-no-gh-cli) section above for the full API reference.
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@
   This template is designed for GenAI coding agents (Claude Code, Copilot, etc.).
   All sections are REQUIRED unless marked [optional].
   See .github/AGENT_PR_GUIDE.md for full tag definitions and enforcement rules.
+
+  IMPORTANT: The `gh` CLI is NOT available in this project's development environment.
+  PRs must be created using `curl` with the GitHub REST API.
+  See .github/AGENT_PR_GUIDE.md for curl examples and the full API reference.
 -->
 
 ## Tags

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,61 @@ AI agents **must** follow the PR template and tag system defined in [`.github/pu
 - Missing data must be handled explicitly — never silently fill gaps with zeros or interpolation without flagging it
 - Cloud LLM providers are opt-in only; LM Studio (local) is always the default
 
+## GitHub API Operations
+
+> **`gh` CLI is NOT available.** This project is primarily developed using Claude Code on the web, where the GitHub CLI (`gh`) is not installed and cannot be used. All GitHub API interactions — creating PRs, commenting on issues, checking workflow status, etc. — **must** use `curl` with the GitHub REST API.
+
+**Authentication:** Use the `GITHUB_TOKEN` environment variable (automatically available in CI and Claude Code web sessions).
+
+**Common operations:**
+
+```bash
+# Create a pull request
+curl -s -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls \
+  -d '{
+    "title": "feat: add portfolio rebalancing calculator",
+    "body": "## Summary\n\nDescription here.\n\n## Tags\n\n- type:feat\n- scope:frontend\n- risk:low",
+    "head": "your-branch-name",
+    "base": "main"
+  }'
+
+# List open pull requests
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls
+
+# Get a specific pull request
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/pulls/123
+
+# Add a comment to a pull request
+curl -s -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/issues/123/comments \
+  -d '{"body": "Your comment here"}'
+
+# List issues
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/issues
+
+# Check workflow runs
+curl -s \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/OWNER/REPO/actions/runs
+```
+
+**Important:** Replace `OWNER/REPO` with the actual repository owner and name (e.g., `Admiralhunter/PortfolioOS`). Always use `$GITHUB_TOKEN` for authentication — never hardcode tokens.
+
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
The gh CLI is not available in Claude Code web sessions. This updates
CLAUDE.md, AGENT_PR_GUIDE.md, and the PR template to explicitly warn
agents against using gh and provide curl + GitHub REST API examples
for all common operations (creating PRs, commenting, checking CI, etc.).

https://claude.ai/code/session_01ELr2o2CdQYG9wLLQqQQRqa