### PR TITLE
docs: add build process audit with TODO tracking

### DIFF
--- a/.github/AGENT_PR_GUIDE.md
+++ b/.github/AGENT_PR_GUIDE.md
@@ -144,6 +144,12 @@ Every PR must verify:
 
 > **The `gh` CLI is NOT available in this project's development environment.** This project is developed using Claude Code on the web, which does not have `gh` installed. **Do not attempt to use `gh` commands.** All GitHub API interactions must use `curl` against the [GitHub REST API](https://docs.github.com/en/rest).
 
+<!-- TODO(BUILD_TODO#13): Raw curl with heredocs and JSON escaping is one of the
+     most fragile operations for LLM agents. Nested quotes, newlines, and special
+     characters in PR descriptions cause silent failures. Consider creating a
+     helper script (e.g., scripts/create-pr.py) that takes structured arguments
+     and handles JSON construction internally. -->
+
 Authenticate with the `GITHUB_TOKEN` environment variable, which is automatically available in Claude Code web sessions and CI.
 
 ### Creating a Pull Request via `curl`
@@ -252,6 +258,12 @@ Look for:
 
 Run the full test and lint suite:
 
+<!-- TODO(BUILD_TODO#2): pnpm lint/test/build don't exist yet (no package.json).
+     These commands will fail. Scaffold package.json with stub scripts or mark
+     them as conditional.
+     TODO(BUILD_TODO#6): There is no root-level unified command to run both
+     Python and JS checks. Agents must remember two toolchains in two
+     directories. Consider a root Makefile or script with a `check-all` target. -->
 ```bash
 pnpm lint
 pnpm test
@@ -368,6 +380,10 @@ risk:medium
 
 ## Enforcement
 
+<!-- TODO(BUILD_TODO#3): No CI/CD workflows exist (.github/workflows/ is empty).
+     All enforcement described here is honor-based with zero automation. Once
+     ci.yml is created, these rules should be enforced via required status checks
+     and branch protection rules. -->
 These rules exist because AI agents can generate plausible-looking PRs that pass superficial review but contain subtle issues: duplicated logic, oversized files, untested edge cases, or security gaps.
 
 The tag system and checklists force agents to slow down, categorize their work, and verify quality before requesting review. Reviewers should:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,11 @@
 <!--
   REQUIRED: Select ALL applicable tags. You MUST pick at least one from each category.
   Delete the tags that do NOT apply. Keep only the ones that describe this PR.
+
+  TODO(BUILD_TODO#11): This "delete what doesn't apply" format is error-prone
+  for LLM agents. They are better at filling in values than deleting lines.
+  Consider switching to a fill-in-the-blank format:
+    **Change type:** (write one: feat/fix/refactor/docs/test/chore/perf/security)
 -->
 
 ### Change Type (pick exactly 1)
@@ -151,6 +156,9 @@
   Include commands run and their output summary.
 -->
 
+<!-- TODO(BUILD_TODO#2): pnpm lint/test/build don't exist yet (no package.json).
+     These checkboxes are unconditional but the commands will fail. Add "if
+     applicable" language or scaffold stub scripts in package.json. -->
 - [ ] `pnpm lint` — passes
 - [ ] `pnpm test` — passes
 - [ ] `pnpm build` — passes
@@ -195,6 +203,10 @@ N/A
 <!--
   REQUIRED for AI agents. This section confirms the agent performed
   genuine verification rather than rubber-stamping checkboxes.
+
+  TODO(BUILD_TODO#12): This attestation is unverifiable without CI. Every LLM
+  will check all boxes regardless. Replace with CI-verified status checks, or
+  require agents to paste actual command output as evidence.
 -->
 
 - [ ] I have **read every file** I modified before making changes

--- a/BUILD_TODO.md
+++ b/BUILD_TODO.md
@@ -1,0 +1,299 @@
+# BUILD_TODO.md — Build & Development Process Issues
+
+Audit date: 2026-02-14
+Audited from: commit `d818f61` (main)
+
+---
+
+## Oversights
+
+### 1. No Root `.gitignore`
+
+- **Severity:** High
+- **Fix effort:** Trivial
+- **Status:** Open
+
+Only `python/.gitignore` exists. The repo root has no `.gitignore`. Once the Electron/React frontend is scaffolded, `node_modules/`, `dist/`, `.vite/`, `.env`, and OS artifacts will get committed on the first careless `git add .`.
+
+**Action:** Create a root `.gitignore` covering Node, Electron, Vite, OS artifacts, IDE files, and environment secrets.
+
+---
+
+### 2. `pnpm` Commands Referenced Everywhere but Don't Exist
+
+- **Severity:** High
+- **Fix effort:** Medium (blocked on Phase 0 frontend scaffolding)
+- **Status:** Open
+
+`CLAUDE.md`, `pull_request_template.md` (lines 154-156), and `AGENT_PR_GUIDE.md` all list `pnpm lint`, `pnpm test`, `pnpm build` as **mandatory** pre-PR verification steps. No `package.json` exists. These commands will fail.
+
+The PR template checkboxes are unconditional — there's no "N/A if no JS changes" escape hatch. An agent doing Python-only work cannot honestly check those boxes.
+
+**Action:**
+- [ ] Scaffold `package.json` with at minimum stub scripts (Phase 0)
+- [ ] Or: make PR template checkboxes conditional — "if applicable" language
+
+---
+
+### 3. No CI/CD Workflows
+
+- **Severity:** High
+- **Fix effort:** Medium
+- **Status:** Open
+
+`docs/ARCHITECTURE.md` and `AGENT_PR_GUIDE.md` reference `.github/workflows/ci.yml` and `.github/workflows/release.yml`. Neither file exists. There is **zero automated enforcement** of any quality gate — the entire PR quality system is honor-based.
+
+**Action:**
+- [ ] Create `.github/workflows/ci.yml` — run Python lint/typecheck/test on push and PR
+- [ ] Create `.github/workflows/release.yml` — build and package on tag (later phase)
+- [ ] Add branch protection rules requiring CI to pass before merge
+
+---
+
+### 4. `master` vs `main` Branch Name Inconsistency
+
+- **Severity:** Medium
+- **Fix effort:** Trivial
+- **Status:** Open
+
+The local default branch may be `master`, but `AGENT_PR_GUIDE.md` tells agents to target `main`. Agents that diff or rebase against `main` locally without fetching will get unexpected errors.
+
+**Action:**
+- [ ] Ensure the repo's default branch is `main` on GitHub
+- [ ] Run `git branch -m master main` if needed locally
+- [ ] Add `init.defaultBranch=main` to repo-level `.gitconfig` or document in CLAUDE.md
+
+---
+
+### 5. Coverage Threshold Permanently Set to 0
+
+- **Severity:** Medium
+- **Fix effort:** Trivial
+- **Status:** Open
+
+`python/pyproject.toml` line 118: `fail_under = 0` with comment "Raise to 80 once implementations land." There's no mechanism (CI check, script, reminder) to trigger that raise. This will silently stay at 0 as real code accumulates, and the CI scripts will report `PASS` with 0% coverage indefinitely.
+
+**Action:**
+- [ ] Add a CI step or script that warns if `fail_under` is 0 and source line count exceeds a threshold (e.g., 500 lines of non-test Python)
+- [ ] Or: raise to 80 as soon as the first real module has tests
+
+---
+
+### 6. No Root-Level Unified Build/Check Script
+
+- **Severity:** Medium
+- **Fix effort:** Low
+- **Status:** Open
+
+The Python sidecar has `scripts/ci.py` for orchestration. There's nothing equivalent at the project root. An agent must remember to run two separate toolchains in two different directories:
+
+```bash
+cd python && uv run python -m scripts.ci   # Python checks
+cd .. && pnpm lint && pnpm test && pnpm build  # JS checks (once they exist)
+```
+
+Agents frequently lose track of their working directory.
+
+**Action:**
+- [ ] Create a root-level `Makefile` or `scripts/check-all.sh` with targets: `check-python`, `check-js`, `check-all`
+- [ ] Or: add a root `package.json` script that orchestrates both
+
+---
+
+### 7. Python Sidecar Has Zero Actual Tests
+
+- **Severity:** Medium
+- **Fix effort:** Medium
+- **Status:** Open
+
+`tests/conftest.py` defines fixtures (`reproducible_rng`, `sample_returns`, `sample_portfolio_value`) but no test files exist. The CI pipeline reports `PASS: 0 passed, 0 failed`, which provides zero safety. Combined with `fail_under = 0`, the Python CI is a no-op.
+
+**Action:**
+- [ ] Add tests for `portfolioos/main.py` (dispatch, message loop, error handling)
+- [ ] Add tests for `scripts/_report.py` (report generation, summary aggregation)
+
+---
+
+### 8. `run_command()` Has No Timeout
+
+- **Severity:** Medium
+- **Fix effort:** Trivial
+- **Status:** Open
+
+`python/scripts/_report.py` line 59: `subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)` — no `timeout` parameter. If `mypy`, `pytest`, or `ruff` hangs (infinite import loop, network stall on a `yfinance` import), the entire CI run blocks forever with no feedback.
+
+**Action:**
+- [ ] Add a `timeout` parameter to `run_command()`, default 120 seconds
+- [ ] Handle `subprocess.TimeoutExpired` and report it as a failure
+
+---
+
+### 9. Sphinx Docs Build in Critical CI Path Without `conf.py`
+
+- **Severity:** Low
+- **Fix effort:** Trivial
+- **Status:** Open
+
+`scripts/ci.py` runs: `lint -> typecheck -> test -> docs -> build`. The Sphinx docs step sits between tests and package build. But there's no `docs/conf.py` checked in — the `docs.py` script will fail immediately, blocking the package build.
+
+For a pre-alpha project with no published docs, this adds friction for no benefit.
+
+**Action:**
+- [ ] Either add a minimal `docs/conf.py` so Sphinx doesn't error
+- [ ] Or: move docs out of the critical CI path (make it optional / non-blocking)
+
+---
+
+### 10. No Pre-Commit Hooks or Commit-Time Validation
+
+- **Severity:** Medium
+- **Fix effort:** Low
+- **Status:** Open
+
+No `.pre-commit-config.yaml`, no `.husky/`, no `.git/hooks/`. An agent can commit malformatted code and push without any guardrail. Given that CI workflows also don't exist, there is **zero automated quality enforcement** at any point in the pipeline.
+
+**Action:**
+- [ ] Add `.pre-commit-config.yaml` with ruff, mypy, and (later) eslint hooks
+- [ ] Or: add a `Makefile` target / npm script that agents run before committing
+
+---
+
+## Agent/LLM-Unfriendly Patterns
+
+### 11. PR Template Requires Manual Tag Deletion
+
+- **Severity:** Medium
+- **Fix effort:** Low
+- **Status:** Open
+
+`pull_request_template.md` lines 20-45 ask agents to "Delete the tags that do NOT apply." LLMs are much better at **selecting/filling** than **deleting lines** from a template. Most LLM-generated PRs will either leave all tags in place or mangle the markdown formatting.
+
+**Action:**
+- [ ] Change to a fill-in-the-blank format: `**Change type:** ___` (agent writes one value)
+- [ ] Or: use structured YAML frontmatter that agents can populate
+
+---
+
+### 12. Agent Attestation Section Is Unverifiable
+
+- **Severity:** Medium
+- **Fix effort:** Medium
+- **Status:** Open
+
+`pull_request_template.md` lines 193-206 ask agents to self-certify claims like "I have **run the test suite** and confirmed it passes." With no CI enforcement, this is purely performative. Every LLM will check the box regardless.
+
+**Action:**
+- [ ] Replace with CI-verified status checks (once CI exists)
+- [ ] Or: require agents to paste actual command output (stdout) as evidence
+- [ ] Or: have CI comment on the PR with verified results
+
+---
+
+### 13. `curl`-Only GitHub API Is Error-Prone for Agents
+
+- **Severity:** Medium
+- **Fix effort:** Medium
+- **Status:** Open
+
+The project forbids `gh` CLI and requires raw `curl` with heredocs and JSON escaping. Constructing multi-line JSON bodies with proper escaping inside `curl -d` is one of the most fragile operations for an LLM. Nested quotes, newlines, and special characters in PR descriptions cause silent failures.
+
+**Action:**
+- [ ] Create a helper script (`scripts/create-pr.py` or `scripts/create-pr.sh`) that takes structured arguments (title, body-file, base, head) and handles JSON construction internally
+- [ ] Or: install `gh` CLI in the development environment
+
+---
+
+### 14. Verbose Output Is Opt-In — Failures Require Two Runs
+
+- **Severity:** Low
+- **Fix effort:** Trivial
+- **Status:** Open
+
+Python CI scripts default to one-line summaries: `[lint] FAIL: 3 errors`. To see details, agents must re-run with `--verbose`. Every failure requires two command invocations to diagnose.
+
+**Action:**
+- [ ] Auto-escalate to verbose on failure: if exit code != 0, print full output
+- [ ] Keep quiet mode for passes — only show details when something goes wrong
+
+---
+
+### 15. `.reports/` Is Gitignored — No Cross-Session State
+
+- **Severity:** Low
+- **Fix effort:** Low
+- **Status:** Open
+
+`.reports/` is in `python/.gitignore`. Each agent session starts cold with no build history. If an agent runs CI, the session ends, and a new session picks up the work, the new session has zero visibility into what previously passed or failed.
+
+**Action:**
+- [ ] Consider committing `summary.json` (but not full reports) to a known location
+- [ ] Or: document that agents should re-run full CI at the start of every session
+
+---
+
+### 16. No `.env.example` or Bootstrap Documentation
+
+- **Severity:** Low
+- **Fix effort:** Trivial
+- **Status:** Open
+
+No inventory of required environment variables, tool versions, or system prerequisites. An agent must read `CLAUDE.md`, `ARCHITECTURE.md`, and `pyproject.toml` to piece together what's needed.
+
+**Action:**
+- [ ] Create `.env.example` with placeholders for `GITHUB_TOKEN`, LM Studio endpoint, optional API keys
+- [ ] Or: add a "Prerequisites" section to the root README with exact version requirements
+
+---
+
+### 17. 206-Line PR Template via JSON Escaping
+
+- **Severity:** High
+- **Fix effort:** Medium
+- **Status:** Open
+
+When an agent creates a PR via `curl`, it must construct a JSON body string containing most of the 206-line template, filled in. That's ~150 lines of markdown being passed through JSON escaping inside a heredoc inside a shell command. The probability of a correctly formatted PR body approaches zero as template length increases.
+
+**Action:**
+- [ ] Shorten the template significantly — move the checklists into CI or a bot comment
+- [ ] Or: create a script that generates the PR body from simple key-value arguments
+- [ ] Or: split the template into required (short) and extended (CI-generated) sections
+
+---
+
+### 18. Test File Naming Convention Mismatch Risk
+
+- **Severity:** Low
+- **Fix effort:** Trivial
+- **Status:** Open
+
+`pyproject.toml` specifies `python_files = ["*_test.py"]` (suffix pattern). An agent coming from the TypeScript world (where `*.test.ts` is the norm) might create `test_something.py` (prefix pattern — the pytest default). The strict `python_files` setting would **silently ignore** those test files.
+
+**Action:**
+- [ ] Add `"test_*.py"` to `python_files` to accept both patterns
+- [ ] Or: add a comment in `pyproject.toml` explicitly warning about this
+- [ ] Or: add a CI check that detects test-like files not matching the naming pattern
+
+---
+
+## Priority Matrix
+
+| # | Issue | Severity | Effort | Priority |
+|---|-------|----------|--------|----------|
+| 1 | No root `.gitignore` | High | Trivial | **P0** |
+| 2 | `pnpm` commands don't exist | High | Medium | **P0** |
+| 3 | No CI/CD workflows | High | Medium | **P0** |
+| 17 | PR template too long for JSON | High | Medium | **P0** |
+| 4 | `master`/`main` mismatch | Medium | Trivial | **P1** |
+| 5 | Coverage threshold at 0 | Medium | Trivial | **P1** |
+| 6 | No unified build command | Medium | Low | **P1** |
+| 7 | Zero actual Python tests | Medium | Medium | **P1** |
+| 8 | `run_command()` no timeout | Medium | Trivial | **P1** |
+| 10 | No pre-commit hooks | Medium | Low | **P1** |
+| 11 | PR template tag deletion | Medium | Low | **P1** |
+| 12 | Unverifiable attestation | Medium | Medium | **P1** |
+| 13 | `curl`-only PR creation | Medium | Medium | **P1** |
+| 9 | Sphinx in critical CI path | Low | Trivial | **P2** |
+| 14 | Verbose output opt-in | Low | Trivial | **P2** |
+| 15 | `.reports/` gitignored | Low | Low | **P2** |
+| 16 | No `.env.example` | Low | Trivial | **P2** |
+| 18 | Test naming mismatch risk | Low | Trivial | **P2** |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,12 @@ curl -s \
 
 ## Common Commands
 
+<!-- TODO(BUILD_TODO#2): pnpm dev/build/test/lint don't exist — no package.json
+     has been created yet. These commands will fail until Phase 0 scaffolding
+     is complete. -->
+<!-- TODO(BUILD_TODO#6): No unified root-level command runs both Python and JS
+     checks. Agents must manually cd between directories. Add a root Makefile
+     or check-all script. -->
 ```bash
 # Development
 pnpm dev                    # Start Electron app in dev mode

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,3 +1,8 @@
+# TODO(BUILD_TODO#1): This is the ONLY .gitignore in the repo. The project root
+# has no .gitignore. Once Electron/React scaffolding lands, node_modules/, dist/,
+# .vite/, .env, and OS artifacts will get committed on the first `git add .`.
+# Create a root-level .gitignore ASAP.
+
 # Python
 __pycache__/
 *.py[cod]

--- a/python/portfolioos/main.py
+++ b/python/portfolioos/main.py
@@ -31,6 +31,9 @@ def dispatch(method: str, params: dict[str, Any]) -> Any:
         ValueError: If the method is not recognized.
 
     """
+    # TODO(BUILD_TODO#7): handlers dict is empty — every call will raise
+    # ValueError("Unknown method"). Wire up simulation/market/analysis
+    # modules as they are implemented, and add tests for dispatch routing.
     handlers: dict[str, Any] = {}
     if method not in handlers:
         msg = f"Unknown method: {method}"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -94,6 +94,9 @@ line-ending = "lf"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# TODO(BUILD_TODO#18): Also accept "test_*.py" prefix pattern — agents from the
+# TypeScript world may create test_foo.py instead of foo_test.py, and pytest will
+# silently skip them with this strict setting.
 python_files = ["*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
@@ -115,7 +118,11 @@ branch = true
 parallel = true
 
 [tool.coverage.report]
-fail_under = 0  # Raise to 80 once implementations land
+# TODO(BUILD_TODO#5): Raise to 80 once implementations land. There is no
+# automated mechanism to trigger this — it will stay at 0 indefinitely
+# unless someone manually bumps it. Consider a CI warning when source
+# lines exceed 500 but fail_under is still 0.
+fail_under = 0
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/python/scripts/_report.py
+++ b/python/scripts/_report.py
@@ -56,6 +56,10 @@ def run_command(
     cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run a subprocess and capture all output."""
+    # TODO(BUILD_TODO#8): Add a timeout parameter (default 120s). If mypy,
+    # pytest, or ruff hangs (e.g., infinite import loop, network stall on
+    # yfinance import), the entire CI run blocks forever with no feedback.
+    # Handle subprocess.TimeoutExpired and report it as a failure.
     return subprocess.run(
         cmd,
         capture_output=True,

--- a/python/scripts/ci.py
+++ b/python/scripts/ci.py
@@ -3,6 +3,16 @@
 Runs: lint -> typecheck -> test -> docs -> build
 Stops at first failure unless --continue-on-error is passed.
 
+TODO(BUILD_TODO#9): Sphinx docs build sits between tests and package build in
+the critical path, but no docs/conf.py exists yet. The docs step will fail
+immediately and block the package build. Consider making docs non-blocking or
+moving it after build.
+
+TODO(BUILD_TODO#14): Verbose output is opt-in. When a step fails, the agent
+gets only a one-line summary and must re-run with --verbose to diagnose.
+Consider auto-escalating to verbose on failure (print full output if exit
+code != 0).
+
 Writes:
     .reports/summary.json  - Aggregate results from all tools
 

--- a/python/scripts/docs.py
+++ b/python/scripts/docs.py
@@ -31,6 +31,10 @@ TOOL_NAME = "docs"
 
 def run(verbose: bool = False) -> dict[str, Any]:
     """Run Sphinx builds (HTML + JSON), write reports, return results."""
+    # TODO(BUILD_TODO#9): No docs/conf.py exists yet. This step will fail
+    # immediately, and since it's in the critical CI path (ci.py runs
+    # lint -> typecheck -> test -> docs -> build), it blocks the package
+    # build. Either add a minimal conf.py or make this step non-blocking.
     report_dir = ensure_report_dir(TOOL_NAME)
     docs_src = PYTHON_ROOT / "docs"
     html_out = report_dir / "html"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,10 @@
-"""Shared pytest fixtures for PortfolioOS analytics tests."""
+"""Shared pytest fixtures for PortfolioOS analytics tests.
+
+TODO(BUILD_TODO#7): Fixtures are defined here but NO actual test files exist.
+The CI pipeline will report PASS with 0 tests. Add tests for at minimum:
+  - portfolioos/main.py (dispatch, message loop, error handling)
+  - scripts/_report.py (report generation, summary aggregation)
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Audit the build/development process for oversights and agent-unfriendly
patterns. Adds BUILD_TODO.md cataloging 18 issues with severity/priority
matrix, and inline TODO comments at each affected location in the codebase.

Key findings: no root .gitignore, pnpm commands referenced but no
package.json exists, no CI/CD workflows, coverage threshold stuck at 0,
no subprocess timeout in run_command(), PR template too long for reliable
JSON escaping by LLM agents.

https://claude.ai/code/session_01KuaVPzJgNoSbNQXyTR4FjN