### PR TITLE
feat: enforce file size, function length, and coverage on git commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,31 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy portfolioos
 
-      - name: Test (pytest)
+      - name: Test + coverage (pytest)
         run: uv run pytest --cov --cov-report=term-missing
+
+  quality-gates:
+    name: Quality gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check file sizes (≤700 effective lines)
+        run: |
+          python scripts/check-file-size.py $(find python/portfolioos python/tests python/scripts src electron \
+            -type f \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+            2>/dev/null || true)
+
+      - name: Check function lengths (≤100 effective lines)
+        run: |
+          python scripts/check-function-length.py $(find python/portfolioos python/tests python/scripts src electron \
+            -type f \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+            2>/dev/null || true)
 
   # JS/TS checks — uncomment once package.json is scaffolded
   # frontend:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,28 @@ repos:
   #   hooks:
   #     - id: eslint
   #       types: [javascript, tsx, typescript]
+
+  # ── Quality gates (file size, function length, coverage) ──────────
+  - repo: local
+    hooks:
+      - id: file-size-check
+        name: "Check file size (≤700 effective lines)"
+        entry: python scripts/check-file-size.py
+        language: python
+        types_or: [python, javascript, tsx, ts]
+        pass_filenames: true
+
+      - id: function-length-check
+        name: "Check function length (≤100 effective lines)"
+        entry: python scripts/check-function-length.py
+        language: python
+        types_or: [python, javascript, tsx, ts]
+        pass_filenames: true
+
+      - id: coverage-check
+        name: "Check test coverage (≥50%)"
+        entry: bash scripts/check-coverage.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check-python check-js check-all lint test
+.PHONY: check-python check-js check-all lint test quality-gates
 
 # ── Python sidecar ──────────────────────────────────────────────
 check-python:
@@ -14,6 +14,18 @@ lint-python:
 test-python:
 	cd python && uv run pytest --cov --cov-report=term-missing
 
+# ── Quality gates (file size + function length) ─────────────────
+quality-gates:
+	@echo "Checking file sizes (≤700 effective lines)..."
+	@python scripts/check-file-size.py $$(find python/portfolioos python/tests python/scripts src electron \
+		-type f \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+		2>/dev/null) || exit 1
+	@echo "Checking function lengths (≤100 effective lines)..."
+	@python scripts/check-function-length.py $$(find python/portfolioos python/tests python/scripts src electron \
+		-type f \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+		2>/dev/null) || exit 1
+	@echo "Quality gates passed."
+
 # ── Frontend (uncomment once package.json exists) ───────────────
 # check-js:
 # 	pnpm lint
@@ -21,7 +33,7 @@ test-python:
 # 	pnpm build
 
 # ── Combined ────────────────────────────────────────────────────
-check-all: check-python
+check-all: check-python quality-gates
 	@echo ""
 	@echo "All checks passed."
 

--- a/python/portfolioos/analysis/returns.py
+++ b/python/portfolioos/analysis/returns.py
@@ -6,8 +6,11 @@ CAGR, rolling returns, drawdown analysis, and total return.
 
 from __future__ import annotations
 
-import numpy as np
-from numpy.typing import NDArray
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
 
 def cagr(

--- a/python/portfolioos/analysis/statistics.py
+++ b/python/portfolioos/analysis/statistics.py
@@ -6,8 +6,11 @@ and other statistical methods for portfolio analysis.
 
 from __future__ import annotations
 
-import numpy as np
-from numpy.typing import NDArray
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
 
 def percentile_rank(

--- a/python/portfolioos/main.py
+++ b/python/portfolioos/main.py
@@ -46,20 +46,20 @@ def main() -> None:
     and writes JSON responses to stdout. Runs indefinitely until
     stdin is closed.
     """
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
+    for raw_line in sys.stdin:
+        stripped = raw_line.strip()
+        if not stripped:
             continue
 
         request: dict[str, Any] = {}
         try:
-            request = json.loads(line)
+            request = json.loads(stripped)
             request_id = request.get("id", "unknown")
             method = request["method"]
             params = request.get("params", {})
             result = dispatch(method, params)
             response: dict[str, Any] = {"id": request_id, "result": result}
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — dispatcher must catch all errors and return them as JSON
             request_id = (
                 request.get("id", "unknown") if isinstance(request, dict) else "unknown"
             )

--- a/python/portfolioos/simulation/monte_carlo.py
+++ b/python/portfolioos/simulation/monte_carlo.py
@@ -12,10 +12,11 @@ References:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
-from numpy.typing import NDArray
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
 
 def run_simulation(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,18 +60,45 @@ src = ["portfolioos", "tests", "scripts"]
 
 [tool.ruff.lint]
 select = [
+    # ── Core style ──
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
     "F",      # pyflakes
     "I",      # isort
     "N",      # pep8-naming
     "UP",     # pyupgrade
-    "B",      # flake8-bugbear
-    "A",      # flake8-builtins
-    "SIM",    # flake8-simplify
-    "RUF",    # ruff-specific rules
     "D",      # pydocstyle
     "ANN",    # flake8-annotations
+
+    # ── Bug prevention ──
+    "B",      # flake8-bugbear — common pitfalls and design problems
+    "A",      # flake8-builtins — shadowing builtins
+    "S",      # flake8-bandit — security issues
+    "BLE",    # flake8-blind-except — overly broad exception catches
+
+    # ── Complexity & size (guides AI agents toward smaller code) ──
+    "C90",    # mccabe — cyclomatic complexity per function
+    "PLR",    # pylint refactor — too many branches/args/returns/statements
+    "PLW",    # pylint warnings — unreachable code, useless statements
+
+    # ── Readability & simplicity ──
+    "SIM",    # flake8-simplify — simplifiable constructs
+    "RET",    # flake8-return — unnecessary else after return, etc.
+    "PIE",    # flake8-pie — misc. cleanliness (no-op expressions, etc.)
+    "ERA",    # eradicate — detect commented-out code
+    "FLY",    # flynt — use f-strings instead of format()/% formatting
+    "PERF",   # perflint — performance anti-patterns
+    "FURB",   # refurb — modernization and idiomatic Python
+
+    # ── Testing ──
+    "PT",     # flake8-pytest-style — consistent pytest idioms
+    "ARG",    # flake8-unused-arguments — dead parameters
+
+    # ── Import hygiene ──
+    "TCH",    # flake8-type-checking — move type-only imports behind TYPE_CHECKING
+
+    # ── Ruff extras ──
+    "RUF",    # ruff-specific rules
 ]
 ignore = [
     "D100",   # missing docstring in public module
@@ -79,11 +106,22 @@ ignore = [
     "D203",   # conflicts with D211
     "D213",   # conflicts with D212
     "ANN401", # allow typing.Any for dispatch/handler patterns
+    "S603",   # allow subprocess calls (needed for build scripts)
+    "S607",   # allow partial executable paths in subprocess
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 10  # flag functions with cyclomatic complexity > 10
+
+[tool.ruff.lint.pylint]
+max-args = 8         # financial functions may need many params (portfolio, withdrawal, etc.)
+max-branches = 12    # keep branching manageable
+max-returns = 6      # too many returns = hard to follow
+max-statements = 50  # proxy for function length — forces decomposition
+
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["D", "ANN", "S101"]
-"scripts/**" = ["D", "ANN"]
+"tests/**" = ["D", "ANN", "S101", "ARG", "PLR0913", "PLR2004", "TCH"]
+"scripts/**" = ["D", "ANN", "S", "BLE", "T20", "PLR2004"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/python/scripts/_report.py
+++ b/python/scripts/_report.py
@@ -74,6 +74,7 @@ def run_command(
             text=True,
             cwd=cwd or PYTHON_ROOT,
             timeout=timeout,
+            check=False,
         )
     except subprocess.TimeoutExpired:
         return subprocess.CompletedProcess(

--- a/python/scripts/build.py
+++ b/python/scripts/build.py
@@ -42,14 +42,11 @@ def run(verbose: bool = False) -> dict[str, Any]:
     artifacts: list[dict[str, Any]] = []
     dist_dir = PYTHON_ROOT / "dist"
     if dist_dir.exists():
-        for f in sorted(dist_dir.iterdir()):
-            if f.is_file() and f.suffix in (".gz", ".whl", ".zip"):
-                artifacts.append(
-                    {
-                        "name": f.name,
-                        "size_bytes": f.stat().st_size,
-                    }
-                )
+        artifacts.extend(
+            {"name": f.name, "size_bytes": f.stat().st_size}
+            for f in sorted(dist_dir.iterdir())
+            if f.is_file() and f.suffix in (".gz", ".whl", ".zip")
+        )
 
     # --- Summary ---
     details: dict[str, Any] = {

--- a/python/scripts/lint.py
+++ b/python/scripts/lint.py
@@ -69,7 +69,7 @@ def run(verbose: bool = False) -> dict[str, Any]:
     format_files = 0
     if not format_clean:
         for line in format_result.stdout.splitlines():
-            if line.startswith("--- ") or line.startswith("would reformat"):
+            if line.startswith(("--- ", "would reformat")):
                 format_files += 1
 
     passed = check_json_result.returncode == 0 and format_clean

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Pre-commit hook: enforce minimum test coverage on commit.
+#
+# Runs pytest with coverage in the Python sidecar and fails if coverage
+# drops below the threshold configured in pyproject.toml (fail_under).
+#
+# This hook runs on ALL commits, not just when Python files change,
+# because any change can indirectly affect coverage (e.g., removing tests).
+#
+# To skip this check for a single commit:
+#   SKIP=coverage-check git commit -m "..."
+
+set -euo pipefail
+
+PYTHON_DIR="$(git rev-parse --show-toplevel)/python"
+
+if [ ! -d "$PYTHON_DIR" ]; then
+    echo "[coverage-check] python/ directory not found, skipping"
+    exit 0
+fi
+
+echo "[coverage-check] Running pytest with coverage..."
+cd "$PYTHON_DIR"
+
+# Run pytest with coverage; fail_under in pyproject.toml enforces the threshold
+if uv run python -m pytest --cov=portfolioos --cov-report=term-missing:skip-covered -q 2>&1; then
+    echo "[coverage-check] PASS"
+    exit 0
+else
+    EXIT_CODE=$?
+    echo ""
+    echo "[coverage-check] FAIL — coverage below threshold or tests failed"
+    echo "Check [tool.coverage.report] fail_under in python/pyproject.toml"
+    exit $EXIT_CODE
+fi

--- a/scripts/check-file-size.py
+++ b/scripts/check-file-size.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: enforce maximum file size (effective lines).
+
+Counts lines excluding comments and blank lines. Exits non-zero if any
+staged file exceeds the threshold.
+
+Thresholds:
+    Source files (.py, .ts, .tsx, .js, .jsx): 700 effective lines
+
+Usage:
+    python scripts/check-file-size.py [FILES...]
+    python scripts/check-file-size.py --threshold 500 [FILES...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 700
+SUPPORTED_EXTENSIONS = {".py", ".ts", ".tsx", ".js", ".jsx"}
+
+# Regex for JS/TS block comment regions
+_JS_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def count_effective_lines_python(source: str) -> int:
+    """Count non-blank, non-comment lines in Python source."""
+    count = 0
+    for line in source.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        count += 1
+    return count
+
+
+def count_effective_lines_js(source: str) -> int:
+    """Count non-blank, non-comment lines in JS/TS source."""
+    # Remove block comments first
+    cleaned = _JS_BLOCK_COMMENT_RE.sub("", source)
+    count = 0
+    for line in cleaned.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("//"):
+            continue
+        count += 1
+    return count
+
+
+def count_effective_lines(filepath: Path) -> int:
+    """Count effective (non-blank, non-comment) lines in a source file."""
+    source = filepath.read_text(encoding="utf-8", errors="replace")
+    if filepath.suffix == ".py":
+        return count_effective_lines_python(source)
+    return count_effective_lines_js(source)
+
+
+def main() -> int:
+    """Check file sizes and return non-zero if any exceed the threshold."""
+    parser = argparse.ArgumentParser(description="Check file size limits")
+    parser.add_argument("files", nargs="*", help="Files to check")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help=f"Max effective lines (default: {DEFAULT_THRESHOLD})",
+    )
+    args = parser.parse_args()
+
+    violations: list[tuple[str, int]] = []
+
+    for filepath_str in args.files:
+        filepath = Path(filepath_str)
+        if filepath.suffix not in SUPPORTED_EXTENSIONS:
+            continue
+        if not filepath.is_file():
+            continue
+
+        effective = count_effective_lines(filepath)
+        if effective > args.threshold:
+            violations.append((filepath_str, effective))
+
+    if violations:
+        print(f"File size violations (>{args.threshold} effective lines):")
+        for name, count in sorted(violations):
+            print(f"  {name}: {count} lines (limit: {args.threshold})")
+        print(
+            "\nEffective lines = total lines minus blank lines and comment-only lines."
+        )
+        print("Split large files into focused modules with single responsibilities.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-function-length.py
+++ b/scripts/check-function-length.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: enforce maximum function length (effective lines).
+
+Parses source files and checks that no function exceeds the line limit.
+For Python files, uses the ast module. For JS/TS files, uses brace-depth
+tracking with regex-based function detection.
+
+Thresholds:
+    Functions/methods: 100 effective lines (excluding comments, blank lines)
+
+Usage:
+    python scripts/check-function-length.py [FILES...]
+    python scripts/check-function-length.py --threshold 80 [FILES...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 100
+PYTHON_EXTENSIONS = {".py"}
+JS_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx"}
+SUPPORTED_EXTENSIONS = PYTHON_EXTENSIONS | JS_EXTENSIONS
+
+# Patterns for JS/TS function detection
+_JS_FUNC_PATTERNS = [
+    # function declarations: function name(
+    re.compile(r"^.*\bfunction\s+(\w+)\s*\("),
+    # arrow functions assigned to const/let/var: const name = (...) =>
+    re.compile(r"^.*\b(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\(.*\)\s*=>"),
+    # method definitions in classes/objects: name( or async name(
+    re.compile(r"^\s+(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{"),
+]
+
+# JS block comment state tracking
+_JS_BLOCK_OPEN = re.compile(r"/\*")
+_JS_BLOCK_CLOSE = re.compile(r"\*/")
+
+
+def _is_python_comment_or_blank(line: str) -> bool:
+    stripped = line.strip()
+    return not stripped or stripped.startswith("#")
+
+
+def _is_js_comment_or_blank(line: str, in_block_comment: bool) -> tuple[bool, bool]:
+    """Return (is_ignorable, still_in_block_comment)."""
+    stripped = line.strip()
+
+    if in_block_comment:
+        if "*/" in stripped:
+            return True, False
+        return True, True
+
+    if not stripped:
+        return True, False
+    if stripped.startswith("//"):
+        return True, False
+    if stripped.startswith("/*"):
+        if "*/" in stripped[2:]:
+            return True, False
+        return True, True
+
+    return False, False
+
+
+def check_python_functions(
+    filepath: Path,
+    threshold: int,
+) -> list[tuple[str, str, int, int]]:
+    """Check Python function lengths using AST.
+
+    Returns list of (filepath, func_name, line_number, effective_lines).
+    """
+    source = filepath.read_text(encoding="utf-8", errors="replace")
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    violations: list[tuple[str, str, int, int]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        func_name = node.name
+        start_line = node.lineno
+        end_line = node.end_lineno or node.lineno
+
+        # Count effective lines within the function body
+        effective = 0
+        for line in lines[start_line - 1 : end_line]:
+            if not _is_python_comment_or_blank(line):
+                effective += 1
+
+        if effective > threshold:
+            violations.append((str(filepath), func_name, start_line, effective))
+
+    return violations
+
+
+def check_js_functions(
+    filepath: Path,
+    threshold: int,
+) -> list[tuple[str, str, int, int]]:
+    """Check JS/TS function lengths using brace-depth tracking.
+
+    Returns list of (filepath, func_name, line_number, effective_lines).
+    """
+    source = filepath.read_text(encoding="utf-8", errors="replace")
+    lines = source.splitlines()
+    violations: list[tuple[str, str, int, int]] = []
+
+    # Track functions by finding declarations and matching braces
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        func_name = None
+
+        for pattern in _JS_FUNC_PATTERNS:
+            match = pattern.match(line)
+            if match:
+                func_name = match.group(1)
+                break
+
+        if func_name and "{" in line:
+            # Track brace depth to find function end
+            start_line = i
+            depth = 0
+            in_block_comment = False
+            effective = 0
+
+            for j in range(i, len(lines)):
+                current_line = lines[j]
+                stripped = current_line.strip()
+
+                # Track block comments for brace counting
+                if in_block_comment:
+                    if "*/" in stripped:
+                        in_block_comment = False
+                    i = j + 1
+                    continue
+                if "/*" in stripped and "*/" not in stripped:
+                    in_block_comment = True
+
+                # Count effective lines
+                is_ignorable, in_block_comment = _is_js_comment_or_blank(
+                    current_line, False
+                )
+                if not is_ignorable:
+                    effective += 1
+
+                # Track brace depth (simplified — doesn't handle braces in strings)
+                for char in stripped:
+                    if char == "{":
+                        depth += 1
+                    elif char == "}":
+                        depth -= 1
+
+                if depth == 0 and j > start_line:
+                    if effective > threshold:
+                        violations.append(
+                            (str(filepath), func_name, start_line + 1, effective)
+                        )
+                    i = j + 1
+                    break
+            else:
+                i += 1
+        else:
+            i += 1
+
+    return violations
+
+
+def main() -> int:
+    """Check function lengths and return non-zero if any exceed the threshold."""
+    parser = argparse.ArgumentParser(description="Check function length limits")
+    parser.add_argument("files", nargs="*", help="Files to check")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help=f"Max effective lines per function (default: {DEFAULT_THRESHOLD})",
+    )
+    args = parser.parse_args()
+
+    all_violations: list[tuple[str, str, int, int]] = []
+
+    for filepath_str in args.files:
+        filepath = Path(filepath_str)
+        if filepath.suffix not in SUPPORTED_EXTENSIONS:
+            continue
+        if not filepath.is_file():
+            continue
+
+        if filepath.suffix in PYTHON_EXTENSIONS:
+            all_violations.extend(check_python_functions(filepath, args.threshold))
+        else:
+            all_violations.extend(check_js_functions(filepath, args.threshold))
+
+    if all_violations:
+        print(f"Function length violations (>{args.threshold} effective lines):")
+        for fpath, fname, lineno, count in sorted(all_violations):
+            print(f"  {fpath}:{lineno} — {fname}(): {count} lines (limit: {args.threshold})")
+        print(
+            "\nEffective lines = total lines minus blank lines and comment-only lines."
+        )
+        print("Extract logical blocks into helper functions and use early returns.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add three pre-commit hooks that block commits when quality gates fail:
- File size: ≤700 effective lines (excluding comments and blank lines)
- Function length: ≤100 effective lines per function/method
- Coverage: ≥50% test coverage (delegates to pytest fail_under)

Expand ruff rules with 14 new rule sets focused on constraining AI agents
from writing bloated code: C90 (complexity), PLR/PLW (pylint refactor),
S (security), BLE (blind except), RET (return consistency), PIE, ERA
(commented-out code), FLY, PERF, FURB, PT (pytest style), ARG (unused
args), and TCH (type-checking imports). Configure pylint thresholds:
max-complexity=10, max-args=8, max-branches=12, max-statements=50.

Fix all 15 existing violations from new rules (TC002 import hygiene,
PLW2901 loop var overwrite, BLE001, PLW1510, PERF401, PIE810).

Add quality-gates CI job and Makefile target for build-time enforcement.

https://claude.ai/code/session_015bKnwy5AptzinRZLSsWxu3