### PR TITLE
chore: add Dependabot configuration for all package managers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # Python dependencies (sidecar) — managed by uv
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 10
+
+  # Python dependencies (agents) — managed by uv
+  - package-ecosystem: "pip"
+    directory: "/agents"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 10
+
+  # Node.js dependencies — managed by pnpm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Configure Dependabot for daily dependency update checks across all ecosystems
- **pip** for `python/` and `agents/` directories (uv-managed Python deps)
- **npm** for root `/` (pnpm-managed Node.js deps, activates once `package.json` is added)
- **github-actions** for workflow action version updates
- Conventional commit prefixes (`chore:`) and descriptive labels on all PRs

## Tags

- type:chore
- scope:ci
- risk:low

## Notes

Dependabot does not support an "every other day" schedule. The closest available interval is `daily`, which is what this config uses.

## Test plan

- [ ] Verify Dependabot picks up the config after merge to `main`
- [ ] Confirm PRs are opened for outdated Python deps in `python/` and `agents/`
- [ ] Confirm GitHub Actions version update PRs are created
- [ ] Confirm npm ecosystem activates once `package.json` is added

https://claude.ai/code/session_01HY5U8yt37RhkAqhwg3fT86