### PR TITLE
Handle network errors gracefully in agent reasoning

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -197,10 +197,20 @@ class Agent:
 
         Useful for agents that can do basic work without an LLM
         (e.g. regex scanning) but produce richer output with one.
+
+        Returns the fallback when:
+        - No LLM provider is configured (``self.llm is None``)
+        - The LLM endpoint is unreachable (connection refused, timeout, etc.)
         """
         if self.llm is None:
             return fallback
-        return self.reason(system, user, **kwargs)
+        try:
+            return self.reason(system, user, **kwargs)
+        except OSError:
+            # OSError covers ConnectionRefusedError, urllib.error.URLError,
+            # TimeoutError, and other network-related failures that indicate
+            # the LLM endpoint is not reachable.
+            return fallback
 
     # -- GitHub Issues helpers ----------------------------------------------
 


### PR DESCRIPTION
## Tags

**Change type:** fix

**Scope:** python, llm

**Risk:** low

---

## Summary

Added graceful error handling for network-related failures in the `reason_or_skip` method. When the LLM endpoint is unreachable (connection refused, URL errors, timeouts, etc.), the method now returns the fallback value instead of raising an exception. This makes agents more resilient when LLM services are temporarily unavailable.

---

## Changes

- `agents/base.py` — Wrapped `self.reason()` call in try-except to catch `OSError` and its subclasses (ConnectionRefusedError, urllib.error.URLError, TimeoutError, etc.), returning fallback on network failures. Updated docstring to document this behavior.
- `agents/tests/base_agent_test.py` — Added two new test cases: `test_connection_error_returns_fallback` and `test_url_error_returns_fallback` to verify fallback is returned when LLM endpoint is unreachable.

---

## Self-Review Checklist

- [x] No duplicated logic — error handling is localized to the method that needs it
- [x] Every file under 700 lines, every function under 100 lines
- [x] Public functions have JSDoc/docstrings; complex logic has "why" comments
- [x] No secrets, `eval()`, `innerHTML`, `any` types, or telemetry added
- [x] New code has tests; existing tests still pass
- [x] Naming follows project conventions (snake_case Python)
- [x] No dead code, commented-out blocks, or debug statements

---

## Testing Done

Added unit tests that verify the fallback behavior when network errors occur:
- `test_connection_error_returns_fallback` — Tests ConnectionRefusedError handling
- `test_url_error_returns_fallback` — Tests urllib.error.URLError handling

Both tests confirm that `reason_or_skip` returns the fallback value when the LLM endpoint is unreachable, rather than propagating the exception.

---

## Size Violations

None

---

## Related Issues

<!-- None identified -->

https://claude.ai/code/session_01Vmj8SjKDEGzuAxHsR96Eku