### PR TITLE
feat: add LLM logging, CI auto-detection, and model updates for todo scanner

### DIFF
--- a/agents/tests/todo_scanner_llm_test.py
+++ b/agents/tests/todo_scanner_llm_test.py
@@ -58,6 +58,8 @@ class TestTodoScannerLLMWithoutLLM:
 
         assert result["markers_found"] == 4  # 2 TODO + 1 FIXME + 1 NOTE
         assert result["actionable"] == 3  # excludes NOTE
+        assert result["llm_used"] is False
+        assert result["llm_provider"] is None
 
     def test_fallback_creates_one_group_per_marker(
         self, scan_dir: Path, tmp_path: Path
@@ -122,6 +124,8 @@ class TestTodoScannerLLMWithLLM:
         result = agent.run()
 
         assert result["groups"] == 2
+        assert result["llm_used"] is True
+        assert result["llm_provider"] == "FakeLLM"
 
     def test_llm_malformed_response_falls_back(
         self, scan_dir: Path, tmp_path: Path


### PR DESCRIPTION
- Add structured logging throughout the agent pipeline so it's clear
  whether an LLM is actually being used or falling back to static mode
- Auto-detect CI/GitHub Actions environment and use Anthropic provider
  when ANTHROPIC_API_KEY is set (agent defaults to claude-haiku)
- Add AGENT_LLM_PROVIDER and AGENT_LLM_MODEL env var overrides for
  explicit control over provider and model ID
- Register claude-haiku provider and update model defaults to latest:
  Haiku 4.5, Sonnet 4.5, Opus 4.6
- Add summary fields (llm_used, llm_provider) to scanner output
- Add tests for _detect_provider_preference auto-detection logic

https://claude.ai/code/session_01QFe9D5qsatWESNk2gragTG