### PR TITLE
fix: pre-rebuild native modules for Electron ABI during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,12 @@ COPY python/ ./python/
 COPY agents/ ./agents/
 COPY scripts/ ./scripts/
 
+# Pre-rebuild native modules (duckdb, better-sqlite3) for Electron's Node ABI.
+# The node-deps stage builds them for Node.js 22, but Electron uses a different
+# ABI. Without this step, electron-forge attempts a runtime rebuild at startup
+# which fails in Docker due to environment/PATH issues with python3.
+RUN npx electron-rebuild 2>&1
+
 # Copy entrypoint (strip Windows \r line endings to prevent "bash\r: not found")
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && \


### PR DESCRIPTION
## Summary

- Pre-rebuild native modules (duckdb, better-sqlite3) for Electron's Node ABI during Docker build instead of at runtime
- Fixes `electron-forge start` crash caused by node-gyp failing to find python3 during the `@electron/rebuild` step

## Problem

When running `docker compose up`, the container crashes at the "Preparing native dependencies" step:

```
gyp ERR! find Python checking if "python3" can be used
gyp ERR! find Python - executable path is ""
gyp ERR! find Python - "" could not be run
Error: Could not find any Python installation to use
✖ Preparing native dependencies: 1 / 2 [FAILED: node-gyp failed to rebuild '/app/node_modules/duckdb']
```

The `node-deps` build stage compiles native modules for Node.js 22's ABI, but Electron uses a different ABI. At startup, `electron-forge start` detects the mismatch and invokes `@electron/rebuild` → `node-gyp`, which fails to locate python3 despite it being installed.

## Solution

Run `npx electron-rebuild` during the Docker build (as root), after python3, make, and g++ are installed and after node_modules are copied. This pre-compiles native modules for the correct Electron ABI, eliminating the fragile runtime rebuild entirely.

## Tags

- type:fix
- scope:docker
- risk:low

## Test plan

- [ ] Run `docker compose up --build` and verify the container starts without node-gyp/python errors
- [ ] Verify the Electron app window appears (with X11 forwarding configured)

https://claude.ai/code/session_01FRWP3LLmgK8ub4zGRjPKBs