### PR TITLE
feat: add FIRE Simulator UI, Market Intelligence, and Settings pages

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -8,6 +8,7 @@
 
 import { contextBridge, ipcRenderer } from "electron";
 import type {
+  AddProviderParams,
   CreateAccountParams,
   LLMOptions,
   ScenarioConfig,
@@ -60,6 +61,10 @@ const api = {
   },
   llm: {
     listProviders: () => ipcRenderer.invoke("llm:list-providers"),
+    addProvider: (params: AddProviderParams) =>
+      ipcRenderer.invoke("llm:add-provider", params),
+    deleteProvider: (providerId: string) =>
+      ipcRenderer.invoke("llm:delete-provider", providerId),
     setDefault: (providerId: string) =>
       ipcRenderer.invoke("llm:set-default", providerId),
     send: (prompt: string, options?: LLMOptions) =>

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -155,6 +155,15 @@ export interface LLMResponse {
   tokensUsed: { prompt: number; completion: number };
 }
 
+export interface AddProviderParams {
+  name: string;
+  provider_type: string;
+  endpoint_url: string;
+  model: string;
+  is_local: boolean;
+  api_key?: string;
+}
+
 // ── Data Source ──
 
 export interface DataSource {

--- a/src/components/fire/FireSimulator.tsx
+++ b/src/components/fire/FireSimulator.tsx
@@ -1,18 +1,129 @@
 /**
- * FIRE Simulator — placeholder for Monte Carlo simulation UI.
+ * FIRE Simulator — Monte Carlo simulation UI with configuration panel,
+ * life events editor, results visualization, and sensitivity analysis.
+ *
+ * Methodology citations:
+ * - Bengen (1994): 4% safe withdrawal rate
+ * - Trinity Study (1998): success rate analysis
+ * - Guyton & Klinger (2006): guardrail withdrawal rules
+ * - Kitces (2008+): rising equity glidepath
  */
 
+import { useState } from "react";
+import { SimulationConfigPanel } from "./SimulationConfigPanel";
+import { LifeEventsEditor } from "./LifeEventsEditor";
+import { ResultsVisualization } from "./ResultsVisualization";
+import { SensitivityAnalysis } from "./SensitivityAnalysis";
+import { useSimulationStore } from "../../stores/simulation";
+import { useRunScenario } from "../../hooks/useSimulation";
+import type { SimulationResult } from "../../types";
+
+function EmptyState({ nTrials, nYears }: { nTrials: number; nYears: number }) {
+  return (
+    <div className="bg-card border border-border rounded-lg p-12 text-center">
+      <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="mx-auto mb-4 text-muted-foreground/40">
+        <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z" />
+      </svg>
+      <p className="text-muted-foreground">
+        Configure your simulation parameters and click{" "}
+        <span className="text-primary font-medium">Run Simulation</span> to see results.
+      </p>
+      <p className="text-xs text-muted-foreground mt-2">
+        Uses {nTrials.toLocaleString()} Monte Carlo trials over {nYears} years
+        with historical S&amp;P 500 returns.
+      </p>
+    </div>
+  );
+}
+
+function LoadingState({ nTrials }: { nTrials: number }) {
+  return (
+    <div className="bg-card border border-border rounded-lg p-12 text-center">
+      <div className="animate-pulse space-y-3">
+        <div className="h-4 bg-muted rounded w-1/3 mx-auto" />
+        <div className="h-48 bg-muted rounded" />
+        <div className="h-4 bg-muted rounded w-2/3 mx-auto" />
+      </div>
+      <p className="text-sm text-muted-foreground mt-4">
+        Running {nTrials.toLocaleString()} Monte Carlo trials...
+      </p>
+    </div>
+  );
+}
+
+function TabSwitcher({
+  active,
+  onSwitch,
+}: {
+  active: string;
+  onSwitch: (tab: "results" | "sensitivity") => void;
+}) {
+  const tabClass = (tab: string) =>
+    `flex-1 py-2 text-sm font-medium rounded-md transition-colors ${
+      active === tab
+        ? "bg-card text-foreground shadow-sm"
+        : "text-muted-foreground hover:text-foreground"
+    }`;
+
+  return (
+    <div className="flex gap-1 bg-muted p-1 rounded-lg">
+      <button onClick={() => onSwitch("results")} className={tabClass("results")}>
+        Results
+      </button>
+      <button onClick={() => onSwitch("sensitivity")} className={tabClass("sensitivity")}>
+        Sensitivity Analysis
+      </button>
+    </div>
+  );
+}
+
 export function FireSimulator() {
+  const { config } = useSimulationStore();
+  const scenario = useRunScenario();
+  const [result, setResult] = useState<SimulationResult | null>(null);
+  const [activeTab, setActiveTab] = useState<"results" | "sensitivity">("results");
+
+  async function handleRun() {
+    try {
+      const data = await scenario.mutateAsync(config);
+      setResult(data);
+    } catch { /* handled by mutation error state */ }
+  }
+
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">FIRE Simulator</h2>
-      <div className="bg-card border border-border rounded-lg p-8 text-center">
-        <p className="text-muted-foreground">
-          Monte Carlo simulation and FIRE analysis coming soon.
+      <div>
+        <h2 className="text-xl font-bold text-foreground">FIRE Simulator</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Monte Carlo simulation for Financial Independence, Retire Early planning.
         </p>
-        <p className="text-xs text-muted-foreground mt-2">
-          Supports constant dollar, constant percentage, and Guyton-Klinger withdrawal strategies.
-        </p>
+      </div>
+      <div className="flex gap-6">
+        <div className="w-80 shrink-0 space-y-4">
+          <SimulationConfigPanel onRun={handleRun} isRunning={scenario.isPending} />
+          <LifeEventsEditor />
+        </div>
+        <div className="flex-1 min-w-0 space-y-4">
+          {scenario.isError && (
+            <div className="p-4 rounded-lg bg-destructive/10 border border-destructive/30 text-destructive text-sm">
+              <p className="font-medium">Simulation failed</p>
+              <p className="mt-1">{scenario.error.message}</p>
+            </div>
+          )}
+          {!result && !scenario.isPending && !scenario.isError && (
+            <EmptyState nTrials={config.n_trials ?? 10_000} nYears={config.n_years ?? 30} />
+          )}
+          {scenario.isPending && <LoadingState nTrials={config.n_trials ?? 10_000} />}
+          {result && !scenario.isPending && (
+            <>
+              <TabSwitcher active={activeTab} onSwitch={setActiveTab} />
+              {activeTab === "results" && (
+                <ResultsVisualization result={result} initialPortfolio={config.initial_portfolio} />
+              )}
+              {activeTab === "sensitivity" && <SensitivityAnalysis />}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/fire/LifeEventsEditor.tsx
+++ b/src/components/fire/LifeEventsEditor.tsx
@@ -1,0 +1,107 @@
+/**
+ * Life events editor — add, edit, and remove temporal events
+ * that affect the simulation (windfalls, expenses, income changes).
+ */
+
+import { useState } from "react";
+import { useSimulationStore } from "../../stores/simulation";
+import type { LifeEvent, LifeEventType } from "../../types";
+
+const EVENT_TYPES: Record<LifeEventType, { label: string }> = {
+  windfall: { label: "Windfall" },
+  expense: { label: "One-time Expense" },
+  income_change: { label: "Income Change" },
+  savings_rate_change: { label: "Savings Rate Change" },
+};
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 bg-muted border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary";
+
+function formatCurrency(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `$${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `$${(abs / 1_000).toFixed(0)}K`;
+  return `$${abs.toFixed(0)}`;
+}
+
+function EventRow({ event, onRemove }: { event: LifeEvent; onRemove: () => void }) {
+  const isPositive = event.type === "windfall" || event.type === "income_change";
+  return (
+    <div className="flex items-center justify-between p-3 rounded-md bg-muted border border-border">
+      <div className="flex items-center gap-3">
+        <span className={`text-xs font-mono px-2 py-0.5 rounded ${isPositive ? "bg-success/10 text-success" : "bg-destructive/10 text-destructive"}`}>
+          Yr {event.year}
+        </span>
+        <div>
+          <p className="text-sm text-foreground">{EVENT_TYPES[event.type].label}</p>
+          <p className="text-xs text-muted-foreground">{event.amount >= 0 ? "+" : ""}{formatCurrency(event.amount)}</p>
+        </div>
+      </div>
+      <button onClick={onRemove} className="text-muted-foreground hover:text-destructive text-xs transition-colors">
+        Remove
+      </button>
+    </div>
+  );
+}
+
+function AddEventForm({ maxYear, onAdd, onCancel }: { maxYear: number; onAdd: (e: LifeEvent) => void; onCancel: () => void }) {
+  const [event, setEvent] = useState<LifeEvent>({ year: 5, type: "windfall", amount: 50_000 });
+
+  return (
+    <div className="p-3 rounded-md border border-primary/30 bg-primary/5 space-y-3">
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground mb-1">Year</label>
+          <input type="number" value={event.year} onChange={(e) => setEvent({ ...event, year: Number(e.target.value) })} min={0} max={maxYear} className={INPUT_CLASS} />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground mb-1">Type</label>
+          <select value={event.type} onChange={(e) => setEvent({ ...event, type: e.target.value as LifeEventType })} className={INPUT_CLASS}>
+            {(Object.keys(EVENT_TYPES) as LifeEventType[]).map((t) => (
+              <option key={t} value={t}>{EVENT_TYPES[t].label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground mb-1">Amount ($)</label>
+          <input type="number" value={event.amount} onChange={(e) => setEvent({ ...event, amount: Number(e.target.value) })} className={INPUT_CLASS} />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button onClick={() => { onAdd(event); onCancel(); }} className="flex-1 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors">
+          Add Life Event
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function LifeEventsEditor() {
+  const { config, addLifeEvent, removeLifeEvent } = useSimulationStore();
+  const events = config.life_events ?? [];
+  const [isAdding, setIsAdding] = useState(false);
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Life Events</h3>
+        <button onClick={() => setIsAdding(!isAdding)} className="text-xs text-primary hover:text-primary/80 transition-colors">
+          {isAdding ? "Cancel" : "+ Add Event"}
+        </button>
+      </div>
+      {events.length === 0 && !isAdding && (
+        <p className="text-xs text-muted-foreground text-center py-4">
+          No life events configured. Add windfalls, expenses, or income changes.
+        </p>
+      )}
+      {events.length > 0 && (
+        <div className="space-y-2">
+          {events.map((event, i) => (
+            <EventRow key={i} event={event} onRemove={() => removeLifeEvent(i)} />
+          ))}
+        </div>
+      )}
+      {isAdding && <AddEventForm maxYear={config.n_years ?? 50} onAdd={addLifeEvent} onCancel={() => setIsAdding(false)} />}
+    </div>
+  );
+}

--- a/src/components/fire/ResultsVisualization.tsx
+++ b/src/components/fire/ResultsVisualization.tsx
@@ -1,0 +1,326 @@
+/**
+ * FIRE simulation results visualization — probability fan chart,
+ * success rate gauge, and summary statistics.
+ *
+ * Fan chart displays 5th/25th/50th/75th/95th percentile portfolio paths.
+ * Success rate shows probability of portfolio surviving the full horizon.
+ * References: Bengen (1994), Trinity Study (1998).
+ */
+
+import {
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Line,
+  ComposedChart,
+} from "recharts";
+import type { SimulationResult } from "../../types";
+
+function formatCurrency(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+function SuccessGauge({ rate }: { rate: number }) {
+  const pct = Math.round(rate * 100);
+  const circumference = 2 * Math.PI * 45;
+  const strokeDashoffset = circumference * (1 - rate);
+  const color =
+    pct >= 90
+      ? "var(--color-success)"
+      : pct >= 70
+        ? "var(--color-warning)"
+        : "var(--color-destructive)";
+
+  return (
+    <div className="flex flex-col items-center">
+      <svg width="120" height="120" viewBox="0 0 100 100">
+        <circle
+          cx="50"
+          cy="50"
+          r="45"
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth="8"
+        />
+        <circle
+          cx="50"
+          cy="50"
+          r="45"
+          fill="none"
+          stroke={color}
+          strokeWidth="8"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+          transform="rotate(-90 50 50)"
+        />
+        <text
+          x="50"
+          y="46"
+          textAnchor="middle"
+          className="text-2xl font-bold"
+          fill="var(--color-foreground)"
+          fontSize="22"
+        >
+          {pct}%
+        </text>
+        <text
+          x="50"
+          y="62"
+          textAnchor="middle"
+          fill="var(--color-muted-foreground)"
+          fontSize="9"
+        >
+          success rate
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="p-3 bg-muted rounded-md">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-sm font-medium text-foreground">{value}</p>
+      {hint && <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>}
+    </div>
+  );
+}
+
+interface FanChartDatum {
+  year: number;
+  p5: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p95: number;
+}
+
+function buildFanChartData(
+  percentiles: Record<number, number[]>
+): FanChartDatum[] {
+  const p5 = percentiles[5] ?? [];
+  const p25 = percentiles[25] ?? [];
+  const p50 = percentiles[50] ?? [];
+  const p75 = percentiles[75] ?? [];
+  const p95 = percentiles[95] ?? [];
+
+  const len = Math.max(p5.length, p25.length, p50.length, p75.length, p95.length);
+  const data: FanChartDatum[] = [];
+
+  for (let i = 0; i < len; i++) {
+    data.push({
+      year: i,
+      p5: p5[i] ?? 0,
+      p25: p25[i] ?? 0,
+      p50: p50[i] ?? 0,
+      p75: p75[i] ?? 0,
+      p95: p95[i] ?? 0,
+    });
+  }
+  return data;
+}
+
+function FanChart({ data }: { data: FanChartDatum[] }) {
+  return (
+    <div className="h-80">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#262626" />
+          <XAxis
+            dataKey="year"
+            tick={{ fill: "#a3a3a3", fontSize: 11 }}
+            stroke="#262626"
+            label={{
+              value: "Year",
+              position: "insideBottomRight",
+              offset: -5,
+              fill: "#a3a3a3",
+              fontSize: 11,
+            }}
+          />
+          <YAxis
+            tickFormatter={formatCurrency}
+            tick={{ fill: "#a3a3a3", fontSize: 11 }}
+            stroke="#262626"
+            width={70}
+          />
+          <Tooltip
+            formatter={(value, name) => {
+              const labels: Record<string, string> = {
+                p5: "5th percentile",
+                p25: "25th percentile",
+                p50: "Median",
+                p75: "75th percentile",
+                p95: "95th percentile",
+              };
+              return [formatCurrency(Number(value ?? 0)), labels[String(name)] ?? String(name)];
+            }}
+            labelFormatter={(label) => `Year ${label}`}
+            contentStyle={{
+              backgroundColor: "#141414",
+              border: "1px solid #262626",
+              borderRadius: "6px",
+              color: "#fafafa",
+              fontSize: "12px",
+            }}
+          />
+
+          {/* 5th-95th band (lightest) */}
+          <Area
+            type="monotone"
+            dataKey="p95"
+            stroke="none"
+            fill="#3b82f6"
+            fillOpacity={0.08}
+            stackId="band-outer"
+          />
+          <Area
+            type="monotone"
+            dataKey="p5"
+            stroke="none"
+            fill="#0a0a0a"
+            fillOpacity={1}
+            stackId="band-outer"
+          />
+
+          {/* 25th-75th band (medium) */}
+          <Area
+            type="monotone"
+            dataKey="p75"
+            stroke="none"
+            fill="#3b82f6"
+            fillOpacity={0.15}
+            stackId="band-inner"
+          />
+          <Area
+            type="monotone"
+            dataKey="p25"
+            stroke="none"
+            fill="#0a0a0a"
+            fillOpacity={1}
+            stackId="band-inner"
+          />
+
+          {/* Median line */}
+          <Line
+            type="monotone"
+            dataKey="p50"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+const STRATEGY_LABELS: Record<string, string> = {
+  constant_dollar: "Constant Dollar (4% Rule)",
+  constant_percentage: "Constant Percentage",
+  guyton_klinger: "Guyton-Klinger Guardrails",
+};
+
+export function ResultsVisualization({
+  result,
+  initialPortfolio,
+}: {
+  result: SimulationResult;
+  initialPortfolio: number;
+}) {
+  const fanData = buildFanChartData(result.percentiles);
+  const withdrawalRate =
+    initialPortfolio > 0
+      ? ((result.percentiles[50]?.[1] !== undefined
+          ? initialPortfolio - (result.percentiles[50]?.[1] ?? 0)
+          : 0) /
+          initialPortfolio) *
+        100
+      : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Top row: success gauge + stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-card border border-border rounded-lg p-4 flex items-center justify-center">
+          <SuccessGauge rate={result.success_rate} />
+        </div>
+        <div className="bg-card border border-border rounded-lg p-4 space-y-3 md:col-span-2">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+            Summary Statistics
+          </h4>
+          <div className="grid grid-cols-2 gap-3">
+            <StatCard
+              label="Median Final Value"
+              value={formatCurrency(result.median_final_value)}
+            />
+            <StatCard
+              label="Strategy"
+              value={STRATEGY_LABELS[result.strategy] ?? result.strategy}
+            />
+            <StatCard
+              label="5th Percentile (Worst Case)"
+              value={formatCurrency(
+                result.percentiles[5]?.[result.percentiles[5].length - 1] ?? 0
+              )}
+              hint="1-in-20 bad outcome"
+            />
+            <StatCard
+              label="95th Percentile (Best Case)"
+              value={formatCurrency(
+                result.percentiles[95]?.[result.percentiles[95].length - 1] ?? 0
+              )}
+              hint="1-in-20 good outcome"
+            />
+          </div>
+          {withdrawalRate > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Effective withdrawal rate: {withdrawalRate.toFixed(1)}%
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Fan chart */}
+      <div className="bg-card border border-border rounded-lg p-4">
+        <h4 className="text-sm font-semibold text-foreground mb-3">
+          Portfolio Value Projections
+        </h4>
+        <p className="text-xs text-muted-foreground mb-4">
+          Probability fan chart showing 5th/25th/50th/75th/95th percentile
+          portfolio paths across {fanData.length > 0 ? fanData.length - 1 : 0}{" "}
+          years.
+        </p>
+        <FanChart data={fanData} />
+        <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="w-4 h-0.5 bg-primary inline-block" /> Median
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-4 h-3 bg-primary/15 inline-block rounded-sm" />{" "}
+            25th-75th
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-4 h-3 bg-primary/8 inline-block rounded-sm" />{" "}
+            5th-95th
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fire/SensitivityAnalysis.tsx
+++ b/src/components/fire/SensitivityAnalysis.tsx
@@ -1,0 +1,146 @@
+/**
+ * Sensitivity analysis — vary a single parameter and visualize
+ * how it affects success rate and median final value.
+ */
+
+import { useState } from "react";
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, Legend,
+} from "recharts";
+import { useSimulationStore } from "../../stores/simulation";
+import { useRunSensitivity } from "../../hooks/useSimulation";
+import type { SensitivityParam, SensitivityResult } from "../../types";
+
+function formatCurrency(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+const TOOLTIP_STYLE = {
+  backgroundColor: "#141414", border: "1px solid #262626",
+  borderRadius: "6px", color: "#fafafa", fontSize: "12px",
+};
+const TICK_STYLE = { fill: "#a3a3a3", fontSize: 11 };
+
+const PARAM_OPTIONS: Record<SensitivityParam, {
+  label: string; defaultValues: number[]; formatValue: (v: number) => string;
+}> = {
+  withdrawal_rate: {
+    label: "Withdrawal Rate",
+    defaultValues: [0.02, 0.025, 0.03, 0.035, 0.04, 0.045, 0.05, 0.055, 0.06],
+    formatValue: (v) => `${(v * 100).toFixed(1)}%`,
+  },
+  inflation_rate: {
+    label: "Inflation Rate",
+    defaultValues: [0.01, 0.02, 0.03, 0.04, 0.05, 0.06],
+    formatValue: (v) => `${(v * 100).toFixed(1)}%`,
+  },
+  n_years: {
+    label: "Time Horizon",
+    defaultValues: [10, 15, 20, 25, 30, 35, 40, 45, 50],
+    formatValue: (v) => `${v}yr`,
+  },
+};
+
+interface ChartRow { param: string; successRate: number; medianFinal: number }
+
+function SensitivityChart({ data }: { data: ChartRow[] }) {
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#262626" />
+          <XAxis dataKey="param" tick={TICK_STYLE} stroke="#262626" />
+          <YAxis yAxisId="left" tick={TICK_STYLE} stroke="#262626" domain={[0, 100]} tickFormatter={(v) => `${v}%`} />
+          <YAxis yAxisId="right" orientation="right" tickFormatter={formatCurrency} tick={TICK_STYLE} stroke="#262626" width={70} />
+          <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(value, name) => {
+            const v = Number(value ?? 0);
+            const n = String(name);
+            return n === "Success Rate" ? [`${v}%`, n] : [formatCurrency(v), n];
+          }} />
+          <Legend wrapperStyle={{ fontSize: "12px", color: "#a3a3a3" }} />
+          <Line yAxisId="left" type="monotone" dataKey="successRate" stroke="#16a34a" strokeWidth={2} dot={{ r: 4 }} name="Success Rate" />
+          <Line yAxisId="right" type="monotone" dataKey="medianFinal" stroke="#3b82f6" strokeWidth={2} dot={{ r: 4 }} name="Median Final Value" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function SensitivityTable({ data, paramLabel }: { data: ChartRow[]; paramLabel: string }) {
+  function rateColor(rate: number) {
+    if (rate >= 90) return "text-success";
+    if (rate >= 70) return "text-warning";
+    return "text-destructive";
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left py-2 px-2 text-muted-foreground font-medium">{paramLabel}</th>
+            <th className="text-right py-2 px-2 text-muted-foreground font-medium">Success Rate</th>
+            <th className="text-right py-2 px-2 text-muted-foreground font-medium">Median Final</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-border/50">
+              <td className="py-1.5 px-2 text-foreground">{row.param}</td>
+              <td className={`py-1.5 px-2 text-right font-medium ${rateColor(row.successRate)}`}>{row.successRate}%</td>
+              <td className="py-1.5 px-2 text-right text-foreground">{formatCurrency(row.medianFinal)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function SensitivityAnalysis() {
+  const { config } = useSimulationStore();
+  const sensitivity = useRunSensitivity();
+  const [selectedParam, setSelectedParam] = useState<SensitivityParam>("withdrawal_rate");
+  const paramInfo = PARAM_OPTIONS[selectedParam];
+
+  function handleRun() {
+    sensitivity.mutate({ ...config, vary_param: selectedParam, values: paramInfo.defaultValues });
+  }
+
+  const chartData: ChartRow[] = (sensitivity.data ?? []).map((r: SensitivityResult) => ({
+    param: paramInfo.formatValue(r.param_value),
+    successRate: Math.round(r.success_rate * 100),
+    medianFinal: r.median_final_value,
+  }));
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-4 space-y-4">
+      <h3 className="text-sm font-semibold text-foreground">Sensitivity Analysis</h3>
+      <p className="text-xs text-muted-foreground">Vary a single parameter to see how it affects FIRE success probability.</p>
+      <div className="flex items-end gap-3">
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-muted-foreground mb-1">Parameter to Vary</label>
+          <select value={selectedParam} onChange={(e) => setSelectedParam(e.target.value as SensitivityParam)} className="w-full px-3 py-2 bg-muted border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
+            {(Object.keys(PARAM_OPTIONS) as SensitivityParam[]).map((p) => (
+              <option key={p} value={p}>{PARAM_OPTIONS[p].label}</option>
+            ))}
+          </select>
+        </div>
+        <button onClick={handleRun} disabled={sensitivity.isPending} className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+          {sensitivity.isPending ? "Analyzing..." : "Run Analysis"}
+        </button>
+      </div>
+      {sensitivity.isError && (
+        <div className="p-3 rounded-md bg-destructive/10 border border-destructive/30 text-destructive text-sm">{sensitivity.error.message}</div>
+      )}
+      {chartData.length > 0 && (
+        <div className="space-y-4">
+          <SensitivityChart data={chartData} />
+          <SensitivityTable data={chartData} paramLabel={paramInfo.label} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/fire/SimulationConfigPanel.tsx
+++ b/src/components/fire/SimulationConfigPanel.tsx
@@ -1,0 +1,109 @@
+/**
+ * FIRE simulation configuration panel — input fields for portfolio parameters,
+ * withdrawal strategy, and FIRE type presets.
+ */
+
+import { useState } from "react";
+import { useSimulationStore, FIRE_PRESETS, WITHDRAWAL_STRATEGIES } from "../../stores/simulation";
+import type { FIREType, WithdrawalStrategy } from "../../types";
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 bg-muted border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary";
+
+function CurrencyField({ label, value, onChange, hint }: {
+  label: string; value: number; onChange: (v: number) => void; hint?: string;
+}) {
+  const [display, setDisplay] = useState(value.toLocaleString("en-US"));
+  function handleBlur() {
+    const parsed = Number(display.replace(/[^0-9.-]/g, "")) || 0;
+    onChange(parsed);
+    setDisplay(parsed.toLocaleString("en-US"));
+  }
+  return (
+    <div>
+      <label className="block text-xs font-medium text-muted-foreground mb-1">{label}</label>
+      <div className="relative">
+        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+        <input type="text" value={display} onChange={(e) => setDisplay(e.target.value)} onBlur={handleBlur} className={`${INPUT_CLASS} pl-7`} />
+      </div>
+      {hint && <p className="text-xs text-muted-foreground mt-1">{hint}</p>}
+    </div>
+  );
+}
+
+function NumberField({ label, value, onChange, min, max, step, suffix, hint }: {
+  label: string; value: number; onChange: (v: number) => void;
+  min?: number; max?: number; step?: number; suffix?: string; hint?: string;
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-muted-foreground mb-1">{label}</label>
+      <div className="relative">
+        <input type="number" value={value} onChange={(e) => onChange(Number(e.target.value))} min={min} max={max} step={step} className={INPUT_CLASS} />
+        {suffix && <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground text-xs">{suffix}</span>}
+      </div>
+      {hint && <p className="text-xs text-muted-foreground mt-1">{hint}</p>}
+    </div>
+  );
+}
+
+function StrategyOption({ strategy, selected, onSelect }: {
+  strategy: WithdrawalStrategy; selected: boolean; onSelect: () => void;
+}) {
+  const info = WITHDRAWAL_STRATEGIES[strategy];
+  return (
+    <label className={`flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors ${selected ? "border-primary bg-primary/5" : "border-border bg-muted hover:border-muted-foreground/30"}`}>
+      <input type="radio" name="withdrawal_strategy" value={strategy} checked={selected} onChange={onSelect} className="mt-0.5 accent-primary" />
+      <div>
+        <p className="text-sm font-medium text-foreground">{info.label}</p>
+        <p className="text-xs text-muted-foreground">{info.description}</p>
+      </div>
+    </label>
+  );
+}
+
+export function SimulationConfigPanel({ onRun, isRunning }: { onRun: () => void; isRunning: boolean }) {
+  const { config, setConfig, resetConfig, applyPreset } = useSimulationStore();
+  const withdrawalHint = config.initial_portfolio > 0
+    ? `${((config.annual_withdrawal / config.initial_portfolio) * 100).toFixed(1)}% withdrawal rate`
+    : undefined;
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-4 space-y-5">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Simulation Configuration</h3>
+        <button onClick={resetConfig} className="text-xs text-muted-foreground hover:text-foreground transition-colors">Reset defaults</button>
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-muted-foreground mb-2">FIRE Type Preset</label>
+        <div className="flex flex-wrap gap-2">
+          {(Object.keys(FIRE_PRESETS) as FIREType[]).map((type) => (
+            <button key={type} onClick={() => applyPreset(type)} className="px-3 py-1.5 text-xs rounded-md border border-border bg-muted text-muted-foreground hover:bg-primary/10 hover:text-primary hover:border-primary/30 transition-colors" title={FIRE_PRESETS[type].description}>
+              {FIRE_PRESETS[type].label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <CurrencyField label="Initial Portfolio" value={config.initial_portfolio} onChange={(v) => setConfig({ initial_portfolio: v })} />
+        <CurrencyField label="Annual Withdrawal" value={config.annual_withdrawal} onChange={(v) => setConfig({ annual_withdrawal: v })} hint={withdrawalHint} />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <NumberField label="Time Horizon" value={config.n_years ?? 30} onChange={(v) => setConfig({ n_years: v })} min={1} max={100} suffix="years" />
+        <NumberField label="Inflation Rate" value={(config.inflation_rate ?? 0.03) * 100} onChange={(v) => setConfig({ inflation_rate: v / 100 })} min={0} max={20} step={0.1} suffix="%" />
+      </div>
+      <NumberField label="Monte Carlo Trials" value={config.n_trials ?? 10_000} onChange={(v) => setConfig({ n_trials: v })} min={100} max={100_000} step={1000} hint="More trials = more accurate but slower. 10,000 is standard." />
+      <div>
+        <label className="block text-xs font-medium text-muted-foreground mb-2">Withdrawal Strategy</label>
+        <div className="space-y-2">
+          {(Object.keys(WITHDRAWAL_STRATEGIES) as WithdrawalStrategy[]).map((s) => (
+            <StrategyOption key={s} strategy={s} selected={config.withdrawal_strategy === s} onSelect={() => setConfig({ withdrawal_strategy: s })} />
+          ))}
+        </div>
+      </div>
+      <button onClick={onRun} disabled={isRunning} className="w-full py-2.5 rounded-md bg-primary text-primary-foreground font-medium text-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+        {isRunning ? "Running Simulation..." : "Run Simulation"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/market/MacroIndicators.tsx
+++ b/src/components/market/MacroIndicators.tsx
@@ -1,0 +1,129 @@
+/**
+ * Macro indicators dashboard — FRED economic data display.
+ * Shows key macro series: fed funds rate, CPI, unemployment, treasury yields.
+ */
+
+import { useState } from "react";
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from "recharts";
+import { useFetchMacroSeries } from "../../hooks/useMarketData";
+import type { MacroRecord } from "../../types";
+
+interface MacroSeries {
+  id: string; label: string; unit: string; color: string;
+}
+
+const MACRO_SERIES: MacroSeries[] = [
+  { id: "FEDFUNDS", label: "Fed Funds Rate", unit: "%", color: "#3b82f6" },
+  { id: "CPIAUCSL", label: "CPI (All Urban)", unit: "Index", color: "#f59e0b" },
+  { id: "UNRATE", label: "Unemployment Rate", unit: "%", color: "#dc2626" },
+  { id: "DGS10", label: "10Y Treasury", unit: "%", color: "#16a34a" },
+  { id: "DGS2", label: "2Y Treasury", unit: "%", color: "#8b5cf6" },
+  { id: "MORTGAGE30US", label: "30Y Mortgage", unit: "%", color: "#ec4899" },
+];
+
+const TOOLTIP_STYLE = {
+  backgroundColor: "#141414", border: "1px solid #262626",
+  borderRadius: "6px", color: "#fafafa", fontSize: "12px",
+};
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+}
+
+function MacroChart({ data, series }: { data: MacroRecord[]; series: MacroSeries }) {
+  if (data.length === 0) return null;
+  const chartData = data.map((r) => ({ date: r.date, value: r.value }));
+  return (
+    <div className="h-48">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#262626" />
+          <XAxis dataKey="date" tickFormatter={formatDate} tick={{ fill: "#a3a3a3", fontSize: 10 }} stroke="#262626" />
+          <YAxis tick={{ fill: "#a3a3a3", fontSize: 10 }} stroke="#262626" width={50} tickFormatter={(v) => series.unit === "%" ? `${v}%` : v.toLocaleString()} />
+          <Tooltip formatter={(value) => { const v = Number(value ?? 0); return [series.unit === "%" ? `${v.toFixed(2)}%` : v.toLocaleString(), series.label]; }} labelFormatter={(label) => new Date(String(label)).toLocaleDateString()} contentStyle={TOOLTIP_STYLE} />
+          <Line type="monotone" dataKey="value" stroke={series.color} strokeWidth={1.5} dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function MacroCard({ series, data, isLoading, onFetch }: {
+  series: MacroSeries; data?: MacroRecord[]; isLoading: boolean; onFetch: () => void;
+}) {
+  const lastValue = data?.[data.length - 1];
+  return (
+    <div className="bg-card border border-border rounded-lg p-4">
+      <div className="flex items-center justify-between mb-2">
+        <div>
+          <p className="text-sm font-medium text-foreground">{series.label}</p>
+          {lastValue && (
+            <p className="text-xs text-muted-foreground">
+              Latest: {series.unit === "%" ? `${lastValue.value.toFixed(2)}%` : lastValue.value.toLocaleString()} ({formatDate(lastValue.date)})
+            </p>
+          )}
+        </div>
+        {!data && (
+          <button onClick={onFetch} disabled={isLoading} className="text-xs px-3 py-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground/30 disabled:opacity-50 transition-colors">
+            {isLoading ? "Loading..." : "Fetch"}
+          </button>
+        )}
+      </div>
+      {isLoading && !data && (
+        <div className="h-48 flex items-center justify-center">
+          <div className="animate-pulse space-y-2 w-full">
+            <div className="h-2 bg-muted rounded w-full" />
+            <div className="h-2 bg-muted rounded w-3/4" />
+          </div>
+        </div>
+      )}
+      {data && <MacroChart data={data} series={series} />}
+      {!data && !isLoading && (
+        <div className="h-48 flex items-center justify-center text-xs text-muted-foreground">
+          Click Fetch to load {series.label} data
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function MacroIndicators() {
+  const fetchMacro = useFetchMacroSeries();
+  const [seriesData, setSeriesData] = useState<Record<string, MacroRecord[]>>({});
+  const [loadingSeries, setLoadingSeries] = useState<Set<string>>(new Set());
+  const dateRange = { start: "2020-01-01", end: new Date().toISOString().split("T")[0] };
+
+  async function handleFetch(seriesId: string) {
+    setLoadingSeries((prev) => new Set(prev).add(seriesId));
+    try {
+      const data = await fetchMacro.mutateAsync({ seriesId, startDate: dateRange.start, endDate: dateRange.end });
+      setSeriesData((prev) => ({ ...prev, [seriesId]: data }));
+    } catch { /* error surfaced in mutation state */ }
+    finally {
+      setLoadingSeries((prev) => { const next = new Set(prev); next.delete(seriesId); return next; });
+    }
+  }
+
+  function handleFetchAll() {
+    for (const s of MACRO_SERIES) { if (!seriesData[s.id]) handleFetch(s.id); }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Macro Economic Indicators</h3>
+        <button onClick={handleFetchAll} disabled={loadingSeries.size > 0} className="text-xs text-primary hover:text-primary/80 disabled:opacity-50 transition-colors">
+          {loadingSeries.size > 0 ? "Loading..." : "Fetch All"}
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground">Federal Reserve Economic Data (FRED). Click a card to fetch data.</p>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {MACRO_SERIES.map((s) => (
+          <MacroCard key={s.id} series={s} data={seriesData[s.id]} isLoading={loadingSeries.has(s.id)} onFetch={() => handleFetch(s.id)} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/market/MarketDashboard.tsx
+++ b/src/components/market/MarketDashboard.tsx
@@ -1,19 +1,177 @@
 /**
- * Market dashboard — placeholder for price charts and macro data.
+ * Market Intelligence dashboard — price charts for individual symbols
+ * and macro economic indicators from FRED.
+ *
+ * Data sources: Yahoo Finance (price history), FRED (macro indicators).
  */
 
+import { useState } from "react";
+import { PriceChart } from "./PriceChart";
+import { MacroIndicators } from "./MacroIndicators";
+import { usePriceHistory, useFetchPriceHistory, useGapDetection } from "../../hooks/useMarketData";
+
+function SymbolSearch({
+  onSearch,
+  isLoading,
+}: {
+  onSearch: (symbol: string, start: string, end: string) => void;
+  isLoading: boolean;
+}) {
+  const [symbol, setSymbol] = useState("SPY");
+  const [startDate, setStartDate] = useState("2024-01-01");
+  const [endDate] = useState(new Date().toISOString().split("T")[0]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (symbol.trim()) {
+      onSearch(symbol.trim().toUpperCase(), startDate, endDate);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-end gap-3">
+      <div>
+        <label className="block text-xs font-medium text-muted-foreground mb-1">
+          Symbol
+        </label>
+        <input
+          type="text"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+          placeholder="e.g., SPY, VTI, AAPL"
+          className="w-32 px-3 py-2 bg-muted border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-muted-foreground mb-1">
+          Start Date
+        </label>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="px-3 py-2 bg-muted border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-muted-foreground mb-1">
+          End Date
+        </label>
+        <input
+          type="date"
+          value={endDate}
+          disabled
+          className="px-3 py-2 bg-muted border border-border rounded-md text-sm text-muted-foreground cursor-not-allowed"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={isLoading || !symbol.trim()}
+        className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {isLoading ? "Fetching..." : "Fetch Data"}
+      </button>
+    </form>
+  );
+}
+
+function GapDetection({ symbol }: { symbol: string }) {
+  const { data: gaps, isLoading } = useGapDetection(symbol);
+
+  if (isLoading || !gaps) return null;
+  if (gaps.length === 0) {
+    return (
+      <p className="text-xs text-success">
+        No data gaps detected for {symbol}.
+      </p>
+    );
+  }
+
+  return (
+    <div className="text-xs">
+      <p className="text-warning font-medium">
+        {gaps.length} data gap{gaps.length !== 1 ? "s" : ""} detected:
+      </p>
+      <div className="flex flex-wrap gap-2 mt-1">
+        {gaps.slice(0, 5).map((gap, i) => (
+          <span
+            key={i}
+            className="px-2 py-0.5 rounded bg-warning/10 text-warning"
+          >
+            {gap.expected_date} ({gap.gap_type})
+          </span>
+        ))}
+        {gaps.length > 5 && (
+          <span className="text-muted-foreground">
+            +{gaps.length - 5} more
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function MarketDashboard() {
+  const fetchPrices = useFetchPriceHistory();
+  const [activeSymbol, setActiveSymbol] = useState("");
+  const { data: cachedPrices } = usePriceHistory(activeSymbol);
+
+  function handleSearch(symbol: string, start: string, end: string) {
+    setActiveSymbol(symbol);
+    fetchPrices.mutate({ symbol, startDate: start, endDate: end });
+  }
+
+  const priceData = cachedPrices ?? fetchPrices.data ?? [];
+
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">Market Intelligence</h2>
-      <div className="bg-card border border-border rounded-lg p-8 text-center">
-        <p className="text-muted-foreground">
-          Market data, price charts, and macro indicators coming soon.
-        </p>
-        <p className="text-xs text-muted-foreground mt-2">
-          Powered by Yahoo Finance and FRED data feeds.
+      <div>
+        <h2 className="text-xl font-bold text-foreground">
+          Market Intelligence
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Price charts and macro economic indicators. Powered by Yahoo Finance
+          and FRED.
         </p>
       </div>
+
+      {/* Price chart section */}
+      <div className="bg-card border border-border rounded-lg p-4 space-y-4">
+        <h3 className="text-sm font-semibold text-foreground">Price Chart</h3>
+        <SymbolSearch
+          onSearch={handleSearch}
+          isLoading={fetchPrices.isPending}
+        />
+
+        {fetchPrices.isError && (
+          <div className="p-3 rounded-md bg-destructive/10 border border-destructive/30 text-destructive text-sm">
+            Failed to fetch price data: {fetchPrices.error.message}
+          </div>
+        )}
+
+        {priceData.length > 0 && (
+          <>
+            <PriceChart data={priceData} symbol={activeSymbol} />
+            <GapDetection symbol={activeSymbol} />
+          </>
+        )}
+
+        {activeSymbol && priceData.length === 0 && !fetchPrices.isPending && (
+          <div className="text-center py-8 text-muted-foreground text-sm">
+            No cached price data for {activeSymbol}. Click Fetch Data to
+            download.
+          </div>
+        )}
+
+        {!activeSymbol && (
+          <div className="text-center py-12 text-muted-foreground text-sm">
+            Enter a symbol and click Fetch Data to display a candlestick chart.
+          </div>
+        )}
+      </div>
+
+      {/* Macro indicators section */}
+      <MacroIndicators />
     </div>
   );
 }

--- a/src/components/market/PriceChart.tsx
+++ b/src/components/market/PriceChart.tsx
@@ -1,0 +1,84 @@
+/**
+ * Price chart — candlestick chart using TradingView's Lightweight Charts v5.
+ * Displays OHLCV data for a single symbol with volume histogram.
+ */
+
+import { useEffect, useRef } from "react";
+import {
+  createChart, CandlestickSeries, HistogramSeries,
+  type IChartApi, type ISeriesApi, ColorType,
+} from "lightweight-charts";
+import type { PriceRecord } from "../../types";
+
+const CHART_OPTIONS = {
+  layout: { background: { type: ColorType.Solid, color: "#141414" }, textColor: "#a3a3a3", fontSize: 11 },
+  grid: { vertLines: { color: "#1e1e1e" }, horzLines: { color: "#1e1e1e" } },
+  crosshair: { vertLine: { color: "#3b82f6", width: 1 as const, style: 2 as const }, horzLine: { color: "#3b82f6", width: 1 as const, style: 2 as const } },
+  rightPriceScale: { borderColor: "#262626" },
+  timeScale: { borderColor: "#262626", timeVisible: false },
+  height: 400,
+};
+
+function useChartSetup(containerRef: React.RefObject<HTMLDivElement | null>) {
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
+  const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const chart = createChart(containerRef.current, { ...CHART_OPTIONS, width: containerRef.current.clientWidth });
+    const candle = chart.addSeries(CandlestickSeries, {
+      upColor: "#16a34a", downColor: "#dc2626",
+      borderUpColor: "#16a34a", borderDownColor: "#dc2626",
+      wickUpColor: "#16a34a", wickDownColor: "#dc2626",
+    });
+    const volume = chart.addSeries(HistogramSeries, { priceFormat: { type: "volume" }, priceScaleId: "volume" });
+    chart.priceScale("volume").applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
+    chartRef.current = chart;
+    candleRef.current = candle;
+    volumeRef.current = volume;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) chart.applyOptions({ width: entry.contentRect.width });
+    });
+    observer.observe(containerRef.current);
+    return () => { observer.disconnect(); chart.remove(); };
+  }, [containerRef]);
+
+  return { chartRef, candleRef, volumeRef };
+}
+
+function ChartHeader({ symbol, data }: { symbol: string; data: PriceRecord[] }) {
+  const last = data.length > 0 ? data[data.length - 1] : null;
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <h4 className="text-sm font-semibold text-foreground">{symbol}</h4>
+      {last && (
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          <span>Last: ${last.close.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          <span>{data.length} data points</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PriceChart({ data, symbol }: { data: PriceRecord[]; symbol: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { chartRef, candleRef, volumeRef } = useChartSetup(containerRef);
+
+  useEffect(() => {
+    if (!candleRef.current || !volumeRef.current || data.length === 0) return;
+    const sorted = [...data].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    candleRef.current.setData(sorted.map((r) => ({ time: r.date as string, open: r.open, high: r.high, low: r.low, close: r.close })));
+    volumeRef.current.setData(sorted.map((r) => ({ time: r.date as string, value: r.volume, color: r.close >= r.open ? "#16a34a40" : "#dc262640" })));
+    chartRef.current?.timeScale().fitContent();
+  }, [data, chartRef, candleRef, volumeRef]);
+
+  return (
+    <div>
+      <ChartHeader symbol={symbol} data={data} />
+      <div ref={containerRef} className="rounded-md overflow-hidden" />
+    </div>
+  );
+}

--- a/src/components/settings/AppPreferences.tsx
+++ b/src/components/settings/AppPreferences.tsx
@@ -1,0 +1,86 @@
+/**
+ * App preferences — theme, data paths, general application settings.
+ */
+
+import { useUIStore } from "../../stores/ui";
+import { usePreferences, useSetPreference } from "../../hooks/usePreferences";
+import type { Preferences } from "../../types";
+
+function ThemeButton({ active, label, hint, onClick }: {
+  active: boolean; label: string; hint: string; onClick: () => void;
+}) {
+  return (
+    <button onClick={onClick} className={`flex-1 p-3 rounded-md border text-sm transition-colors ${active ? "border-primary bg-primary/5 text-foreground" : "border-border bg-muted text-muted-foreground hover:text-foreground"}`}>
+      <span className="block font-medium">{label}</span>
+      <span className="text-xs text-muted-foreground">{hint}</span>
+    </button>
+  );
+}
+
+function StoredPreferences({ prefs }: { prefs: Preferences }) {
+  const entries = Object.entries(prefs);
+  if (entries.length === 0) return null;
+  return (
+    <div>
+      <label className="block text-xs font-medium text-muted-foreground mb-2">Stored Preferences</label>
+      <div className="bg-muted rounded-md p-3 space-y-1">
+        {entries.map(([key, value]) => (
+          <div key={key} className="flex justify-between text-xs">
+            <span className="text-muted-foreground font-mono">{key}</span>
+            <span className="text-foreground">{value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AboutSection() {
+  return (
+    <>
+      <div className="pt-4 border-t border-border">
+        <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">About</h4>
+        <div className="space-y-1 text-xs text-muted-foreground">
+          <p><span className="font-medium text-foreground">PortfolioOS</span> v0.1.0</p>
+          <p>Local-first, privacy-preserving desktop application for personal finance management and FIRE analysis.</p>
+          <p>License: PolyForm Noncommercial 1.0.0</p>
+        </div>
+      </div>
+      <div className="p-3 rounded-md bg-muted text-xs text-muted-foreground space-y-1">
+        <p className="font-medium text-foreground">Data Storage</p>
+        <p>All data is stored locally. DuckDB handles analytics; SQLite stores preferences.</p>
+        <p>No data is sent externally unless you enable cloud LLM providers and consent.</p>
+      </div>
+    </>
+  );
+}
+
+export function AppPreferences() {
+  const { theme, setTheme } = useUIStore();
+  const { data: preferences, isLoading } = usePreferences();
+  const setPreference = useSetPreference();
+
+  function handleThemeChange(newTheme: "dark" | "light") {
+    setTheme(newTheme);
+    setPreference.mutate({ key: "theme", value: newTheme });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">Application Preferences</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">General settings for the PortfolioOS application.</p>
+      </div>
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-muted-foreground">Theme</label>
+        <div className="flex gap-2">
+          <ThemeButton active={theme === "dark"} label="Dark" hint="Easy on the eyes" onClick={() => handleThemeChange("dark")} />
+          <ThemeButton active={theme === "light"} label="Light" hint="High contrast" onClick={() => handleThemeChange("light")} />
+        </div>
+      </div>
+      {isLoading && <div className="animate-pulse h-20 bg-muted rounded" />}
+      {preferences && <StoredPreferences prefs={preferences} />}
+      <AboutSection />
+    </div>
+  );
+}

--- a/src/components/settings/LLMProviderSettings.tsx
+++ b/src/components/settings/LLMProviderSettings.tsx
@@ -1,0 +1,155 @@
+/**
+ * LLM provider settings — list, add, remove, and set default LLM providers.
+ *
+ * Supports LM Studio (local, default), OpenAI, Anthropic, and OpenRouter.
+ * API keys are stored in the OS keychain via Electron safeStorage.
+ */
+
+import { useState } from "react";
+import {
+  useProviders, useAddProvider, useDeleteProvider, useSetDefaultProvider, useLLMSend,
+} from "../../hooks/useLLM";
+import type { LLMProvider, LLMProviderType } from "../../types";
+
+const INPUT_CLASS = "w-full px-3 py-2 bg-muted border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary";
+
+const PROVIDER_DEFAULTS: Record<LLMProviderType, { endpoint: string; model: string; isLocal: boolean }> = {
+  lmstudio: { endpoint: "http://localhost:1234/v1", model: "local-model", isLocal: true },
+  openai: { endpoint: "https://api.openai.com/v1", model: "gpt-4o", isLocal: false },
+  anthropic: { endpoint: "https://api.anthropic.com/v1", model: "claude-sonnet-4-20250514", isLocal: false },
+  openrouter: { endpoint: "https://openrouter.ai/api/v1", model: "anthropic/claude-sonnet-4-20250514", isLocal: false },
+};
+
+function FormField({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div><label className="block text-xs font-medium text-muted-foreground mb-1">{label}</label>{children}</div>;
+}
+
+function AddProviderForm({ onClose }: { onClose: () => void }) {
+  const addProvider = useAddProvider();
+  const [name, setName] = useState("");
+  const [providerType, setProviderType] = useState<LLMProviderType>("lmstudio");
+  const [endpoint, setEndpoint] = useState(PROVIDER_DEFAULTS.lmstudio.endpoint);
+  const [model, setModel] = useState(PROVIDER_DEFAULTS.lmstudio.model);
+  const [apiKey, setApiKey] = useState("");
+
+  function handleTypeChange(type: LLMProviderType) {
+    setProviderType(type);
+    setEndpoint(PROVIDER_DEFAULTS[type].endpoint);
+    setModel(PROVIDER_DEFAULTS[type].model);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await addProvider.mutateAsync({
+      name: name || `${providerType} provider`, provider_type: providerType,
+      endpoint_url: endpoint, model, is_local: PROVIDER_DEFAULTS[providerType].isLocal,
+      api_key: apiKey || undefined,
+    });
+    onClose();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 rounded-lg border border-primary/30 bg-primary/5 space-y-4">
+      <h4 className="text-sm font-semibold text-foreground">Add LLM Provider</h4>
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Name"><input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="My Provider" className={INPUT_CLASS} /></FormField>
+        <FormField label="Provider Type">
+          <select value={providerType} onChange={(e) => handleTypeChange(e.target.value as LLMProviderType)} className={INPUT_CLASS}>
+            <option value="lmstudio">LM Studio (Local)</option>
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="openrouter">OpenRouter</option>
+          </select>
+        </FormField>
+      </div>
+      <FormField label="Endpoint URL"><input type="url" value={endpoint} onChange={(e) => setEndpoint(e.target.value)} className={INPUT_CLASS} /></FormField>
+      <FormField label="Model"><input type="text" value={model} onChange={(e) => setModel(e.target.value)} className={INPUT_CLASS} /></FormField>
+      {!PROVIDER_DEFAULTS[providerType].isLocal && (
+        <FormField label="API Key">
+          <input type="password" value={apiKey} onChange={(e) => setApiKey(e.target.value)} placeholder="sk-..." className={INPUT_CLASS} />
+          <p className="text-xs text-muted-foreground mt-1">Stored in OS keychain via Electron safeStorage.</p>
+        </FormField>
+      )}
+      {addProvider.isError && <p className="text-xs text-destructive">{addProvider.error.message}</p>}
+      <div className="flex gap-2">
+        <button type="submit" disabled={addProvider.isPending} className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors">{addProvider.isPending ? "Adding..." : "Add Provider"}</button>
+        <button type="button" onClick={onClose} className="px-4 py-2 rounded-md border border-border text-sm text-muted-foreground hover:text-foreground transition-colors">Cancel</button>
+      </div>
+    </form>
+  );
+}
+
+function TestConnection() {
+  const send = useLLMSend();
+  const [result, setResult] = useState<string | null>(null);
+  async function handleTest() {
+    setResult(null);
+    try {
+      const r = await send.mutateAsync({ prompt: "Reply with exactly: Connection successful", options: { maxTokens: 50, temperature: 0 } });
+      setResult(`Connected: ${r.model} responded.`);
+    } catch (err) { setResult(`Failed: ${(err as Error).message}`); }
+  }
+  return (
+    <div className="flex items-center gap-3">
+      <button onClick={handleTest} disabled={send.isPending} className="text-xs px-3 py-1.5 rounded-md border border-border text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors">{send.isPending ? "Testing..." : "Test Connection"}</button>
+      {result && <span className={`text-xs ${result.startsWith("Connected") ? "text-success" : "text-destructive"}`}>{result}</span>}
+    </div>
+  );
+}
+
+function ProviderCard({ provider, onSetDefault, onDelete }: {
+  provider: LLMProvider; onSetDefault: () => void; onDelete: () => void;
+}) {
+  return (
+    <div className={`p-4 rounded-lg border ${provider.is_default ? "border-primary bg-primary/5" : "border-border bg-card"}`}>
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-foreground">{provider.name}</p>
+            {provider.is_default && <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary">Default</span>}
+            {provider.is_local && <span className="text-xs px-2 py-0.5 rounded-full bg-success/10 text-success">Local</span>}
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">{provider.provider_type} &middot; {provider.model}</p>
+          <p className="text-xs text-muted-foreground">{provider.endpoint_url}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {!provider.is_default && <button onClick={onSetDefault} className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground transition-colors">Set Default</button>}
+          <button onClick={onDelete} className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-destructive hover:border-destructive/30 transition-colors">Remove</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function LLMProviderSettings() {
+  const { data: providers, isLoading, isError, error } = useProviders();
+  const deleteProvider = useDeleteProvider();
+  const setDefault = useSetDefaultProvider();
+  const [isAdding, setIsAdding] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">LLM Providers</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">Configure language model providers for portfolio queries.</p>
+        </div>
+        <button onClick={() => setIsAdding(!isAdding)} className="text-xs text-primary hover:text-primary/80 transition-colors">{isAdding ? "Cancel" : "+ Add Provider"}</button>
+      </div>
+      {isAdding && <AddProviderForm onClose={() => setIsAdding(false)} />}
+      {isLoading && <div className="animate-pulse space-y-2"><div className="h-16 bg-muted rounded" /><div className="h-16 bg-muted rounded" /></div>}
+      {isError && <div className="p-3 rounded-md bg-destructive/10 border border-destructive/30 text-destructive text-sm">Failed to load providers: {error.message}</div>}
+      {providers && providers.length === 0 && <div className="p-6 text-center text-muted-foreground text-sm">No providers configured. Add one to enable AI features.</div>}
+      {providers && providers.length > 0 && (
+        <div className="space-y-2">
+          {providers.map((p) => <ProviderCard key={p.id} provider={p} onSetDefault={() => setDefault.mutate(p.id)} onDelete={() => deleteProvider.mutate(p.id)} />)}
+        </div>
+      )}
+      <div className="pt-2 border-t border-border"><TestConnection /></div>
+      <div className="p-3 rounded-md bg-muted text-xs text-muted-foreground space-y-1">
+        <p className="font-medium text-foreground">Privacy Notice</p>
+        <p>LM Studio (local) has full data access. Cloud providers require explicit consent before portfolio data is shared.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,18 +1,53 @@
 /**
- * Settings page — app preferences and LLM provider configuration.
+ * Settings page — LLM provider configuration and app preferences.
  */
 
+import { useState } from "react";
+import { LLMProviderSettings } from "./LLMProviderSettings";
+import { AppPreferences } from "./AppPreferences";
+
+type SettingsTab = "llm" | "preferences";
+
 export function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<SettingsTab>("llm");
+
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">Settings</h2>
-      <div className="bg-card border border-border rounded-lg p-8 text-center">
-        <p className="text-muted-foreground">
-          LLM provider settings and app preferences coming soon.
+      <div>
+        <h2 className="text-xl font-bold text-foreground">Settings</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure LLM providers and application preferences.
         </p>
-        <p className="text-xs text-muted-foreground mt-2">
-          Configure LM Studio (local), OpenAI, Anthropic, or OpenRouter.
-        </p>
+      </div>
+
+      {/* Tab switcher */}
+      <div className="flex gap-1 bg-muted p-1 rounded-lg w-fit">
+        <button
+          onClick={() => setActiveTab("llm")}
+          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            activeTab === "llm"
+              ? "bg-card text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          LLM Providers
+        </button>
+        <button
+          onClick={() => setActiveTab("preferences")}
+          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            activeTab === "preferences"
+              ? "bg-card text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Preferences
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="bg-card border border-border rounded-lg p-6">
+        {activeTab === "llm" && <LLMProviderSettings />}
+        {activeTab === "preferences" && <AppPreferences />}
       </div>
     </div>
   );

--- a/src/hooks/useLLM.ts
+++ b/src/hooks/useLLM.ts
@@ -1,0 +1,73 @@
+/**
+ * TanStack Query hooks for LLM provider operations via IPC.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AddProviderParams, LLMOptions } from "../types";
+
+export function useProviders() {
+  return useQuery({
+    queryKey: ["llm-providers"],
+    queryFn: async () => {
+      const response = await window.api.llm.listProviders();
+      if (!response.success) throw new Error(response.error);
+      return response.data!;
+    },
+  });
+}
+
+export function useAddProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (params: AddProviderParams) => {
+      const response = await window.api.llm.addProvider(params);
+      if (!response.success) throw new Error(response.error);
+      return response.data!;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+    },
+  });
+}
+
+export function useDeleteProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (providerId: string) => {
+      const response = await window.api.llm.deleteProvider(providerId);
+      if (!response.success) throw new Error(response.error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+    },
+  });
+}
+
+export function useSetDefaultProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (providerId: string) => {
+      const response = await window.api.llm.setDefault(providerId);
+      if (!response.success) throw new Error(response.error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+    },
+  });
+}
+
+export function useLLMSend() {
+  return useMutation({
+    mutationFn: async ({
+      prompt,
+      options,
+    }: {
+      prompt: string;
+      options?: LLMOptions;
+    }) => {
+      const response = await window.api.llm.send(prompt, options);
+      if (!response.success) throw new Error(response.error);
+      return response.data!;
+    },
+  });
+}

--- a/src/hooks/useMarketData.ts
+++ b/src/hooks/useMarketData.ts
@@ -2,7 +2,7 @@
  * TanStack Query hooks for market data operations via IPC.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export function usePriceHistory(
   symbol: string,
@@ -16,6 +16,56 @@ export function usePriceHistory(
       return response.data!;
     },
     enabled: !!symbol,
+  });
+}
+
+export function useFetchPriceHistory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      symbol,
+      startDate,
+      endDate,
+    }: {
+      symbol: string;
+      startDate: string;
+      endDate: string;
+    }) => {
+      const response = await window.api.market.fetchPriceHistory(
+        symbol,
+        startDate,
+        endDate
+      );
+      if (!response.success) throw new Error(response.error);
+      return response.data!;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["prices", variables.symbol],
+      });
+    },
+  });
+}
+
+export function useFetchMacroSeries() {
+  return useMutation({
+    mutationFn: async ({
+      seriesId,
+      startDate,
+      endDate,
+    }: {
+      seriesId: string;
+      startDate: string;
+      endDate: string;
+    }) => {
+      const response = await window.api.market.fetchMacroSeries(
+        seriesId,
+        startDate,
+        endDate
+      );
+      if (!response.success) throw new Error(response.error);
+      return response.data!;
+    },
   });
 }
 

--- a/src/hooks/usePreferences.ts
+++ b/src/hooks/usePreferences.ts
@@ -1,0 +1,29 @@
+/**
+ * TanStack Query hooks for app preferences via IPC.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export function usePreferences() {
+  return useQuery({
+    queryKey: ["preferences"],
+    queryFn: async () => {
+      const response = await window.api.system.getPreferences();
+      if (!response.success) throw new Error(response.error);
+      return response.data!;
+    },
+  });
+}
+
+export function useSetPreference() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ key, value }: { key: string; value: string }) => {
+      const response = await window.api.system.setPreference(key, value);
+      if (!response.success) throw new Error(response.error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["preferences"] });
+    },
+  });
+}

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -1,28 +1,158 @@
 /**
- * Simulation state store — current simulation configuration.
+ * Simulation state store — current simulation and scenario configuration.
+ *
+ * Manages FIRE simulation parameters, withdrawal strategies, life events,
+ * and FIRE type presets. Persists config across view switches.
  */
 
 import { create } from "zustand";
-import type { SimulationConfig } from "../types";
+import type {
+  ScenarioConfig,
+  LifeEvent,
+  WithdrawalStrategy,
+  FIREType,
+} from "../types";
 
-interface SimulationState {
-  config: SimulationConfig;
-  setConfig: (config: Partial<SimulationConfig>) => void;
-  resetConfig: () => void;
+/** Historical S&P 500 annual real returns (1928-2023) for bootstrap sampling. */
+const HISTORICAL_RETURNS = [
+  0.4381, -0.0830, -0.2512, -0.4384, -0.0864, 0.4998, -0.0119, 0.4674,
+  0.3194, -0.3534, 0.2928, -0.0110, -0.1067, -0.1277, 0.1942, 0.2551,
+  0.1928, 0.3572, -0.0810, 0.0570, 0.0518, 0.1831, 0.3081, 0.2389,
+  0.1811, -0.0121, 0.5256, 0.3262, 0.0744, -0.1046, 0.4372, 0.1206,
+  0.0034, 0.2664, -0.0881, 0.2261, 0.1642, 0.1244, -0.0998, 0.2380,
+  0.1081, -0.0366, 0.1494, -0.1731, -0.2997, 0.3146, 0.2431, -0.0718,
+  0.0656, 0.1844, 0.3242, -0.0491, 0.2155, 0.2256, 0.0627, 0.3173,
+  0.1867, 0.0525, 0.1661, 0.3169, -0.0310, 0.3047, 0.0762, 0.1008,
+  0.0132, 0.3758, 0.2296, 0.3336, 0.2858, 0.2104, -0.0910, -0.1189,
+  -0.2210, 0.2868, 0.1088, 0.0491, 0.1579, 0.0549, -0.3700, 0.2646,
+  0.1506, 0.0211, 0.1600, 0.3239, 0.1369, 0.0138, 0.1196, 0.2183,
+  -0.0438, 0.3149, 0.1840, 0.2861, -0.1830, 0.2837, -0.1932, 0.2471,
+];
+
+interface FIREPreset {
+  label: string;
+  description: string;
+  annual_expenses: number;
+  savings_rate: number;
 }
 
-const DEFAULT_CONFIG: SimulationConfig = {
+export const FIRE_PRESETS: Record<FIREType, FIREPreset> = {
+  lean: {
+    label: "Lean FIRE",
+    description: "Minimal expenses, frugal lifestyle",
+    annual_expenses: 30_000,
+    savings_rate: 0.60,
+  },
+  normal: {
+    label: "Normal FIRE",
+    description: "Moderate lifestyle, standard 4% rule",
+    annual_expenses: 50_000,
+    savings_rate: 0.40,
+  },
+  fat: {
+    label: "Fat FIRE",
+    description: "Comfortable expenses, premium lifestyle",
+    annual_expenses: 100_000,
+    savings_rate: 0.30,
+  },
+  coast: {
+    label: "Coast FIRE",
+    description: "Enough invested, no more contributions needed",
+    annual_expenses: 50_000,
+    savings_rate: 0.0,
+  },
+  barista: {
+    label: "Barista FIRE",
+    description: "Part-time income covers gap between expenses and withdrawals",
+    annual_expenses: 40_000,
+    savings_rate: 0.10,
+  },
+};
+
+export const WITHDRAWAL_STRATEGIES: Record<
+  WithdrawalStrategy,
+  { label: string; description: string }
+> = {
+  constant_dollar: {
+    label: "Constant Dollar (4% Rule)",
+    description: "Fixed inflation-adjusted withdrawal (Bengen 1994)",
+  },
+  constant_percentage: {
+    label: "Constant Percentage",
+    description: "Fixed percentage of current portfolio value each year",
+  },
+  guyton_klinger: {
+    label: "Guyton-Klinger Guardrails",
+    description:
+      "Dynamic rules with prosperity raises and capital preservation cuts (Guyton & Klinger 2006)",
+  },
+};
+
+interface SimulationState {
+  config: ScenarioConfig;
+  setConfig: (config: Partial<ScenarioConfig>) => void;
+  resetConfig: () => void;
+  addLifeEvent: (event: LifeEvent) => void;
+  removeLifeEvent: (index: number) => void;
+  updateLifeEvent: (index: number, event: LifeEvent) => void;
+  applyPreset: (type: FIREType) => void;
+}
+
+const DEFAULT_CONFIG: ScenarioConfig = {
   initial_portfolio: 1_000_000,
   annual_withdrawal: 40_000,
-  return_distribution: [],
+  return_distribution: HISTORICAL_RETURNS,
   n_trials: 10_000,
   n_years: 30,
   inflation_rate: 0.03,
+  withdrawal_strategy: "constant_dollar",
+  life_events: [],
 };
 
 export const useSimulationStore = create<SimulationState>((set) => ({
   config: DEFAULT_CONFIG,
+
   setConfig: (partial) =>
     set((state) => ({ config: { ...state.config, ...partial } })),
+
   resetConfig: () => set({ config: DEFAULT_CONFIG }),
+
+  addLifeEvent: (event) =>
+    set((state) => ({
+      config: {
+        ...state.config,
+        life_events: [...(state.config.life_events ?? []), event],
+      },
+    })),
+
+  removeLifeEvent: (index) =>
+    set((state) => ({
+      config: {
+        ...state.config,
+        life_events: (state.config.life_events ?? []).filter(
+          (_, i) => i !== index
+        ),
+      },
+    })),
+
+  updateLifeEvent: (index, event) =>
+    set((state) => ({
+      config: {
+        ...state.config,
+        life_events: (state.config.life_events ?? []).map((e, i) =>
+          i === index ? event : e
+        ),
+      },
+    })),
+
+  applyPreset: (type) =>
+    set((state) => {
+      const preset = FIRE_PRESETS[type];
+      return {
+        config: {
+          ...state.config,
+          annual_withdrawal: preset.annual_expenses,
+        },
+      };
+    }),
 }));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -22,6 +22,7 @@ import type {
   LLMProvider,
   LLMOptions,
   LLMResponse,
+  AddProviderParams,
   ImportResult,
   AppPaths,
   Preferences,
@@ -55,6 +56,8 @@ export interface SimulationAPI {
 
 export interface LLMAPI {
   listProviders(): Promise<IPCResponse<LLMProvider[]>>;
+  addProvider(params: AddProviderParams): Promise<IPCResponse<{ id: string; name: string }>>;
+  deleteProvider(providerId: string): Promise<IPCResponse<void>>;
   setDefault(providerId: string): Promise<IPCResponse<void>>;
   send(prompt: string, options?: LLMOptions): Promise<IPCResponse<LLMResponse>>;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,14 +105,27 @@ export interface SimulationConfig {
   seed?: number;
 }
 
+export type WithdrawalStrategy =
+  | "constant_dollar"
+  | "constant_percentage"
+  | "guyton_klinger";
+
+export type LifeEventType =
+  | "windfall"
+  | "expense"
+  | "income_change"
+  | "savings_rate_change";
+
+export type FIREType = "lean" | "normal" | "fat" | "coast" | "barista";
+
 export interface ScenarioConfig extends SimulationConfig {
-  withdrawal_strategy?: string;
+  withdrawal_strategy?: WithdrawalStrategy;
   life_events?: LifeEvent[];
 }
 
 export interface LifeEvent {
   year: number;
-  type: string;
+  type: LifeEventType;
   amount: number;
 }
 
@@ -129,6 +142,11 @@ export interface SensitivityResult {
   success_rate: number;
   median_final_value: number;
 }
+
+export type SensitivityParam =
+  | "withdrawal_rate"
+  | "inflation_rate"
+  | "n_years";
 
 // ── LLM ──
 
@@ -153,6 +171,26 @@ export interface LLMResponse {
   content: string;
   model: string;
   tokensUsed: { prompt: number; completion: number };
+}
+
+export type LLMProviderType =
+  | "lmstudio"
+  | "openai"
+  | "anthropic"
+  | "openrouter";
+
+export interface AddProviderParams {
+  name: string;
+  provider_type: LLMProviderType;
+  endpoint_url: string;
+  model: string;
+  is_local: boolean;
+  api_key?: string;
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
 }
 
 // ── Data Source ──


### PR DESCRIPTION
## Summary

Implements **Priority 3** (FIRE Simulator UI) and **Priority 4** (Market Intelligence & Settings) from the project roadmap.

### FIRE Simulator (Priority 3)
- **Simulation config panel**: Initial portfolio, annual withdrawal, time horizon, inflation rate, Monte Carlo trial count
- **FIRE type presets**: Lean, Normal, Fat, Coast, Barista — one-click configuration
- **Withdrawal strategies**: Constant Dollar (Bengen 1994), Constant Percentage, Guyton-Klinger Guardrails (2006)
- **Life events editor**: Add temporal events (windfalls, expenses, income changes) at specific simulation years
- **Results visualization**: Probability fan chart (5th/25th/50th/75th/95th percentile paths), SVG success rate gauge, summary statistics
- **Sensitivity analysis**: Vary withdrawal rate, inflation rate, or time horizon with dual-axis chart (success rate + median final value)

### Market Intelligence (Priority 4)
- **Candlestick price chart**: TradingView Lightweight Charts v5 with OHLCV data and volume histogram
- **Symbol search**: Fetch price history by symbol and date range, with data gap detection
- **Macro indicators**: 6 FRED economic series (Fed Funds, CPI, Unemployment, 10Y/2Y Treasury, 30Y Mortgage) with line charts

### Settings (Priority 4)
- **LLM provider management**: Add/remove/set default for LM Studio, OpenAI, Anthropic, OpenRouter
- **Connection testing**: Test default provider connectivity
- **App preferences**: Theme toggle (dark/light), stored preferences display, about section
- **Privacy notice**: Clear disclosure about local vs. cloud data handling

### Infrastructure
- Extended type system with `WithdrawalStrategy`, `FIREType`, `SensitivityParam`, `AddProviderParams`, `ChatMessage`
- New hooks: `useLLM` (5 hooks), `usePreferences` (2 hooks), extended `useMarketData` (2 new mutations)
- Updated simulation store with scenario config, life events, FIRE presets, and historical S&P 500 returns
- Preload IPC extended for `llm:add-provider` and `llm:delete-provider`

## Tags
- type:feat
- scope:frontend
- scope:fire
- scope:market
- scope:settings
- risk:low

## Test plan
- [x] `make check-all` passes (TypeScript clean, 24 tests passing)
- [x] File sizes ≤ 700 lines
- [x] Function lengths ≤ 100 lines
- [ ] Manual: Navigate to FIRE Simulator, configure parameters, run simulation
- [ ] Manual: Navigate to Market Intelligence, fetch price data, view macro indicators
- [ ] Manual: Navigate to Settings, add/remove LLM providers, toggle theme

https://claude.ai/code/session_015BTg3PZrebrRqpyRVJBkiN